### PR TITLE
add basic Ch.stream

### DIFF
--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -26,4 +26,17 @@ defmodule Ch do
     query = Query.build(statement, Keyword.get(opts, :command))
     DBConnection.execute!(conn, query, params, opts)
   end
+
+  @doc false
+  @spec stream(DBConnection.t(), iodata, list, Keyword.t()) :: DBConnection.Stream.t()
+  def stream(conn, statement, params \\ [], opts \\ []) do
+    query = Query.build(statement, Keyword.get(opts, :command))
+    DBConnection.stream(conn, query, params, opts)
+  end
+
+  @doc false
+  @spec run(DBConnection.conn(), (DBConnection.t() -> any), Keyword.t()) :: any
+  def run(conn, f, opts \\ []) when is_function(f, 1) do
+    DBConnection.run(conn, f, opts)
+  end
 end

--- a/lib/ch/connection.ex
+++ b/lib/ch/connection.ex
@@ -78,18 +78,50 @@ defmodule Ch.Connection do
   end
 
   @impl true
-  def handle_declare(_query, _params, _opts, conn) do
-    {:error, Error.exception("cursors are not supported"), conn}
+  def handle_declare(query, params, opts, conn) do
+    %Query{statement: statement} = query
+
+    format = Keyword.get(opts, :format) || "RowBinary"
+    path = path(settings(conn, opts) ++ params(params))
+    headers = [{"x-clickhouse-format", format} | headers(conn, opts)]
+
+    with {:ok, conn, ref} <- send_request(conn, "POST", path, headers, statement) do
+      {:ok, query, ref, conn}
+    end
   end
 
   @impl true
-  def handle_fetch(_query, _cursor, _opts, conn) do
-    {:error, Error.exception("cursors are not supported"), conn}
+  def handle_fetch(_query, ref, opts, conn) do
+    case HTTP.recv(conn, 0, timeout(conn, opts)) do
+      {:ok, conn, responses} ->
+        case stream_finished?(responses, ref) do
+          true -> {:halt, responses, conn}
+          false -> {:cont, responses, conn}
+        end
+
+      {:error, conn, reason, _responses} ->
+        {:disconnect, reason, conn}
+    end
   end
 
+  defp stream_finished?([{:done, ref}], ref), do: true
+
+  defp stream_finished?([{tag, ref, _data} | responses], ref)
+       when tag in [:status, :headers, :data] do
+    stream_finished?(responses, ref)
+  end
+
+  defp stream_finished?([], _ref), do: false
+
   @impl true
-  def handle_deallocate(_query, _cursor, _opts, conn) do
-    {:error, Error.exception("cursors are not supported"), conn}
+  def handle_deallocate(_query, _ref, _opts, conn) do
+    case HTTP.open_request_count(conn) do
+      0 ->
+        {:ok, [], conn}
+
+      1 ->
+        {:disconnect, Error.exception("cannot stop stream before receiving full response"), conn}
+    end
   end
 
   @impl true


### PR DESCRIPTION
This PR adds a basic `Ch.stream` implementation that just streams "raw" Mint packets. I'm hiding it behind `@doc false` until we add an automatic decoder there. For now we need it for for the SELECT benchmarks.