### PR TITLE
refactor Query.encode/decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ iex> rows = [
 ]
 iex> stream = Stream.map(rows, fn row -> Ch.RowBinary.encode_row(row, types) end)
 
-iex> {:ok, %{num_rows: 4}} = Ch.query(conn, "INSERT INTO helloworld.my_first_table(user_id, message, timestamp, metric) FORMAT RowBinary", stream)
+iex> {:ok, %{num_rows: 4}} = Ch.query(conn, "INSERT INTO helloworld.my_first_table(user_id, message, timestamp, metric) FORMAT RowBinary", {:raw, stream})
 
 iex> {:ok, %{rows: rows}} = Ch.query(conn, "SELECT * FROM helloworld.my_first_table")
 iex> rows
@@ -83,7 +83,7 @@ csv = """
 """
 
 File.write!("example.csv", csv)
-{:ok, _} = Ch.query(conn, "INSERT INTO example(a, b) FORMAT CSV", File.stream!("example.csv"))
+{:ok, _} = Ch.query(conn, "INSERT INTO example(a, b) FORMAT CSV", {:raw, File.stream!("example.csv")})
 ```
 
 - CSV with headers inserts
@@ -97,7 +97,7 @@ a,b
 """
 
 File.write!("example.csv", csv)
-{:ok, _} = Ch.query(conn, "INSERT INTO example FORMAT CSVWithNames", File.stream!("example.csv"))
+{:ok, _} = Ch.query(conn, "INSERT INTO example FORMAT CSVWithNames", {:raw, File.stream!("example.csv")})
 ```
 
 - Custom [settings](https://clickhouse.com/docs/en/operations/settings/)

--- a/bench/insert_stream.exs
+++ b/bench/insert_stream.exs
@@ -9,7 +9,7 @@ database = System.get_env("CH_DATABASE") || "ch_bench"
 Ch.query!(conn, "CREATE DATABASE IF NOT EXISTS {$0:Identifier}", [database])
 
 Ch.query!(conn, """
-CREATE TABLE #{database}.benchmark (
+CREATE TABLE IF NOT EXISTS #{database}.benchmark (
   col1 UInt64,
   col2 String,
   col3 Array(UInt8),
@@ -37,7 +37,7 @@ Benchee.run(
         |> Stream.chunk_every(60_000)
         |> Stream.map(fn chunk -> Ch.RowBinary.encode_rows(chunk, types) end)
 
-      Ch.query!(conn, statement, stream)
+      Ch.query!(conn, statement, {:raw, stream})
     end
   },
   inputs: %{

--- a/bench/stream.exs
+++ b/bench/stream.exs
@@ -10,26 +10,22 @@ statement = fn limit ->
   "SELECT number FROM system.numbers_mt LIMIT #{limit}"
 end
 
-run_stream = fn statement, f ->
-  Ch.run(
-    conn,
-    fn conn -> conn |> Ch.stream(statement, [], format: "RowBinary") |> f.() end,
-    timeout: :infinity
-  )
+run_stream = fn statement, opts ->
+  f = fn conn -> conn |> Ch.stream(statement, [], opts) |> Stream.run() end
+  Ch.run(conn, f, timeout: :infinity)
 end
 
 Benchee.run(
   %{
-    "stream without decode" => fn count ->
-      statement = statement.(count)
-      run_stream.(statement, fn stream -> Stream.run(stream) end)
+    "stream without decode" => fn statement ->
+      run_stream.(statement, _opts = [])
     end,
-    "stream with decode" => fn count ->
-      statement = statement.(count)
-
-      run_stream.(statement, fn stream ->
-        stream
-        |> Stream.each(fn responses ->
+    # TODO why is this faster?
+    "stream with manual decode" => fn statement ->
+      f = fn conn ->
+        conn
+        |> Ch.stream(statement, [], format: "RowBinary")
+        |> Stream.map(fn responses ->
           Enum.each(responses, fn
             {:data, _ref, data} -> Ch.RowBinary.decode_rows(data, [:u64])
             {:status, _ref, 200} -> :ok
@@ -38,12 +34,17 @@ Benchee.run(
           end)
         end)
         |> Stream.run()
-      end)
+      end
+
+      Ch.run(conn, f, timeout: :infinity)
+    end,
+    "stream with decode" => fn statement ->
+      run_stream.(statement, types: [:u64])
     end
   },
   inputs: %{
-    "small (500 rows)" => 500,
-    "medium (500_000 rows)" => 500_000,
-    "large (500_000_000 rows)" => 500_000_000
+    "500 rows" => statement.(500),
+    "500_000 rows" => statement.(500_000),
+    "500_000_000 rows" => statement.(500_000_000)
   }
 )

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -55,17 +55,185 @@ defmodule Ch.Query do
   # TODO cover more cases, don't rely on assumed format
   def extract_command([first | _]), do: extract_command(first)
   def extract_command(_other), do: nil
+end
 
-  defimpl DBConnection.Query do
-    def parse(query, _opts), do: query
-    def describe(query, _opts), do: query
-    def encode(_query, params, _opts), do: params
-    def decode(_query, result, _opts), do: result
+defimpl DBConnection.Query, for: Ch.Query do
+  alias Ch.{Query, Result, RowBinary}
+
+  @spec parse(Query.t(), Keyword.t()) :: Query.t()
+  def parse(query, _opts), do: query
+
+  @spec describe(Query.t(), Keyword.t()) :: Query.t()
+  def describe(query, _opts), do: query
+
+  @spec encode(Query.t(), params, Keyword.t()) :: {query_params, Mint.Types.headers(), body}
+        when raw: iodata | Enumerable.t(),
+             params: map | list(term) | {:raw, raw},
+             query_params: [{String.t(), String.t()}],
+             body: raw
+
+  def encode(%Query{command: :insert, statement: statement}, {:raw, data}, _opts) do
+    body =
+      case data do
+        _ when is_list(data) or is_binary(data) -> [statement, ?\n | data]
+        _ -> Stream.concat([[statement, ?\n]], data)
+      end
+
+    {_query_params = [], _extra_headers = [], body}
   end
 
-  defimpl String.Chars do
-    def to_string(%{statement: statement}) do
-      IO.iodata_to_binary(statement)
+  def encode(%Query{command: :insert, statement: statement}, params, _opts) do
+    {query_params(params), _extra_headers = [], statement}
+  end
+
+  def encode(%Query{statement: statement}, params, opts) do
+    types = Keyword.get(opts, :types)
+    default_format = if types, do: "RowBinary", else: "RowBinaryWithNamesAndTypes"
+    format = Keyword.get(opts, :format) || default_format
+    {query_params(params), [{"x-clickhouse-format", format}], statement}
+  end
+
+  @spec decode(Query.t(), [response], Keyword.t()) :: Result.t()
+        when response: Mint.Types.status() | Mint.Types.headers() | binary
+  def decode(%Query{command: :insert}, responses, _opts) do
+    [_status, headers | _data] = responses
+
+    num_rows =
+      if summary = get_header(headers, "x-clickhouse-summary") do
+        %{"written_rows" => written_rows} = Jason.decode!(summary)
+        String.to_integer(written_rows)
+      end
+
+    %Result{num_rows: num_rows, rows: nil, command: :insert, headers: headers}
+  end
+
+  def decode(%Query{command: command}, responses, opts) when is_list(responses) do
+    # TODO potentially fails on x-progress-headers
+    [_status, headers | data] = responses
+
+    case get_header(headers, "x-clickhouse-format") do
+      "RowBinary" ->
+        types = Keyword.fetch!(opts, :types)
+        rows = data |> IO.iodata_to_binary() |> RowBinary.decode_rows(types)
+        %Result{num_rows: length(rows), rows: rows, command: command, headers: headers}
+
+      "RowBinaryWithNamesAndTypes" ->
+        rows = data |> IO.iodata_to_binary() |> RowBinary.decode_rows()
+        %Result{num_rows: length(rows), rows: rows, command: command, headers: headers}
+
+      _other ->
+        %Result{rows: data, command: command, headers: headers}
     end
+  end
+
+  # TODO merge :stream `decode/3` with "normal" `decode/3` clause above
+  @spec decode(Query.t(), {:stream, nil, responses}, Keyword.t()) :: responses
+        when responses: [Mint.Types.response()]
+  def decode(_query, {:stream, nil, responses}, _opts), do: responses
+
+  @spec decode(Query.t(), {:stream, [atom], [Mint.Types.response()]}, Keyword.t()) :: [[term]]
+  def decode(_query, {:stream, types, responses}, _opts) do
+    decode_stream_data(responses, types)
+  end
+
+  defp decode_stream_data([{:data, _ref, data} | rest], types) do
+    [RowBinary.decode_rows(data, types) | decode_stream_data(rest, types)]
+  end
+
+  defp decode_stream_data([_ | rest], types), do: decode_stream_data(rest, types)
+  defp decode_stream_data([] = done, _types), do: done
+
+  defp get_header(headers, key) do
+    case List.keyfind(headers, key, 0) do
+      {_, value} -> value
+      nil = not_found -> not_found
+    end
+  end
+
+  defp query_params(params) when is_map(params) do
+    Enum.map(params, fn {k, v} -> {"param_#{k}", encode_param(v)} end)
+  end
+
+  defp query_params(params) when is_list(params) do
+    params
+    |> Enum.with_index()
+    |> Enum.map(fn {v, idx} -> {"param_$#{idx}", encode_param(v)} end)
+  end
+
+  defp encode_param(n) when is_integer(n), do: Integer.to_string(n)
+  defp encode_param(f) when is_float(f), do: Float.to_string(f)
+  defp encode_param(b) when is_binary(b), do: b
+  defp encode_param(b) when is_boolean(b), do: b
+  defp encode_param(%Decimal{} = d), do: Decimal.to_string(d, :normal)
+  defp encode_param(%Date{} = date), do: date
+  defp encode_param(%NaiveDateTime{} = naive), do: NaiveDateTime.to_iso8601(naive)
+
+  defp encode_param(%DateTime{} = dt) do
+    dt |> DateTime.to_naive() |> NaiveDateTime.to_iso8601()
+  end
+
+  defp encode_param(a) when is_list(a) do
+    IO.iodata_to_binary([?[, encode_array_params(a), ?]])
+  end
+
+  defp encode_array_params([last]), do: encode_array_param(last)
+
+  defp encode_array_params([s | rest]) do
+    [encode_array_param(s), ?, | encode_array_params(rest)]
+  end
+
+  defp encode_array_params([] = empty), do: empty
+
+  defp encode_array_param(s) when is_binary(s) do
+    [?', to_iodata(s, 0, s, []), ?']
+  end
+
+  defp encode_array_param(v), do: encode_param(v)
+
+  @dialyzer {:no_improper_lists, to_iodata: 4, to_iodata: 5}
+
+  @doc false
+  # based on based on https://github.com/elixir-plug/plug/blob/main/lib/plug/html.ex#L41-L80
+  def to_iodata(binary, skip, original, acc)
+
+  escapes = [{?', "\\'"}, {?\\, "\\\\"}]
+
+  for {match, insert} <- escapes do
+    def to_iodata(<<unquote(match), rest::bits>>, skip, original, acc) do
+      to_iodata(rest, skip + 1, original, [acc | unquote(insert)])
+    end
+  end
+
+  def to_iodata(<<_char, rest::bits>>, skip, original, acc) do
+    to_iodata(rest, skip, original, acc, 1)
+  end
+
+  def to_iodata(<<>>, _skip, _original, acc) do
+    acc
+  end
+
+  for {match, insert} <- escapes do
+    defp to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, len) do
+      part = binary_part(original, skip, len)
+      to_iodata(rest, skip + len + 1, original, [acc, part | unquote(insert)])
+    end
+  end
+
+  defp to_iodata(<<_char, rest::bits>>, skip, original, acc, len) do
+    to_iodata(rest, skip, original, acc, len + 1)
+  end
+
+  defp to_iodata(<<>>, 0, original, _acc, _len) do
+    original
+  end
+
+  defp to_iodata(<<>>, skip, original, acc, len) do
+    [acc | binary_part(original, skip, len)]
+  end
+end
+
+defimpl String.Chars, for: Ch.Query do
+  def to_string(%{statement: statement}) do
+    IO.iodata_to_binary(statement)
   end
 end

--- a/lib/ch/result.ex
+++ b/lib/ch/result.ex
@@ -8,17 +8,15 @@ defmodule Ch.Result do
         row, each element in the inner list corresponds to a column;
       - raw iodata when the response is not automatically decoded, e.g. `x-clickhouse-format: CSV`
     * `num_rows` - The number of fetched or affected rows;
-    * `meta` - A map of metadata collected from the response headers like `x-clickhouse-format`,
-      `x-clickhouse-query-id`, `x-clickhouse-summary`, etc.
+    * `headers` - The HTTP response headers
   """
 
-  defstruct [:command, :meta, :num_rows, :rows]
+  defstruct [:command, :num_rows, :rows, :headers]
 
-  @type summary :: %{String.t() => String.t()}
   @type t :: %__MODULE__{
           command: atom,
-          meta: %{String.t() => String.t() | summary},
-          num_rows: non_neg_integer,
-          rows: [[term]] | iodata | nil
+          num_rows: non_neg_integer | nil,
+          rows: [[term]] | iodata | nil,
+          headers: Mint.Types.headers()
         }
 end

--- a/test/ch/faults_test.exs
+++ b/test/ch/faults_test.exs
@@ -355,7 +355,7 @@ defmodule Ch.FaultsTest do
 
           spawn_link(fn ->
             assert {:error, %Mint.TransportError{reason: :closed}} =
-                     Ch.query(conn, "insert into example(a,b) format RowBinary", stream)
+                     Ch.query(conn, "insert into example(a,b) format RowBinary", {:raw, stream})
           end)
 
           # reconnect
@@ -367,7 +367,7 @@ defmodule Ch.FaultsTest do
 
           spawn_link(fn ->
             assert {:error, %Ch.Error{code: 60, message: message}} =
-                     Ch.query(conn, "insert into example(a,b) format RowBinary", stream)
+                     Ch.query(conn, "insert into example(a,b) format RowBinary", {:raw, stream})
 
             assert message =~ ~r/UNKNOWN_TABLE/
 
@@ -404,7 +404,7 @@ defmodule Ch.FaultsTest do
 
           spawn_link(fn ->
             assert {:error, %Mint.TransportError{reason: :closed}} =
-                     Ch.query(conn, "insert into example(a,b) format RowBinary", stream)
+                     Ch.query(conn, "insert into example(a,b) format RowBinary", {:raw, stream})
           end)
 
           # close after first packet from mint arrives
@@ -420,7 +420,7 @@ defmodule Ch.FaultsTest do
 
           spawn_link(fn ->
             assert {:error, %Ch.Error{code: 60, message: message}} =
-                     Ch.query(conn, "insert into example(a,b) format RowBinary", stream)
+                     Ch.query(conn, "insert into example(a,b) format RowBinary", {:raw, stream})
 
             assert message =~ ~r/UNKNOWN_TABLE/
 
@@ -442,9 +442,8 @@ defmodule Ch.FaultsTest do
       test = self()
 
       header = "X-ClickHouse-Server-Display-Name"
-
-      {:ok, %Ch.Result{meta: %{"server-display-name" => expected_name}}} =
-        Ch.Test.sql_exec("select 1")
+      {:ok, %Result{headers: headers}} = Ch.Test.sql_exec("select 1")
+      {_, expected_name} = List.keyfind!(headers, String.downcase(header), 0)
 
       log =
         capture_async_log(fn ->


### PR DESCRIPTION
This PR moves params encoding to `DBConnection.Query.encode/3` and responses decoding to `DBConnection.Query.decode/3`. This should potentially lower the time we spend in a "checked out" connection.