### PR TITLE
add type helpers for easier type discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Ch.query!(pid, "CREATE TABLE IF NOT EXISTS ch_demo(id UInt64) ENGINE Null")
 Ch.query!(pid, "CREATE TABLE IF NOT EXISTS ch_demo(id UInt64) ENGINE Null")
 
 %Ch.Result{num_rows: 2} =
-  Ch.query!(pid, "INSERT INTO ch_demo(id) FORMAT RowBinary", [[0], [1]], types: [:u64])
+  Ch.query!(pid, "INSERT INTO ch_demo(id) FORMAT RowBinary", [[0], [1]], types: [Ch.u64])
 ```
 
 </details>
@@ -114,7 +114,7 @@ Ch.query!(pid, "CREATE TABLE IF NOT EXISTS ch_demo(id UInt64) ENGINE Null")
 
 stream = Stream.repeatedly(fn -> [:rand.uniform(100)] end)
 chunked = Stream.chunk_every(stream, 100)
-encoded = Stream.map(chunked, fn chunk -> Ch.RowBinary.encode_rows(chunk, [:u64]) end)
+encoded = Stream.map(chunked, fn chunk -> Ch.RowBinary.encode_rows(chunk, [Ch.u64]) end)
 ten_encoded_chunks = Stream.take(encoded, 10)
 
 %Ch.Result{num_rows: 1000} =

--- a/bench/insert_stream.exs
+++ b/bench/insert_stream.exs
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS #{database}.benchmark (
 ) Engine Null
 """)
 
-types = [:u64, :string, {:array, :u8}, :datetime]
+types = [Ch.u64(), Ch.string(), Ch.array(Ch.u8()), Ch.datetime()]
 statement = "INSERT INTO #{database}.benchmark FORMAT RowBinary"
 
 Benchee.run(

--- a/bench/stream.exs
+++ b/bench/stream.exs
@@ -15,6 +15,8 @@ run_stream = fn statement, opts ->
   Ch.run(conn, f, timeout: :infinity)
 end
 
+types = [Ch.u64()]
+
 Benchee.run(
   %{
     "stream without decode" => fn statement ->
@@ -27,7 +29,7 @@ Benchee.run(
         |> Ch.stream(statement, [], format: "RowBinary")
         |> Stream.map(fn responses ->
           Enum.each(responses, fn
-            {:data, _ref, data} -> Ch.RowBinary.decode_rows(data, [:u64])
+            {:data, _ref, data} -> Ch.RowBinary.decode_rows(data, types)
             {:status, _ref, 200} -> :ok
             {:headers, _ref, _headers} -> :ok
             {:done, _ref} -> :ok
@@ -39,7 +41,7 @@ Benchee.run(
       Ch.run(conn, f, timeout: :infinity)
     end,
     "stream with decode" => fn statement ->
-      run_stream.(statement, types: [:u64])
+      run_stream.(statement, types: types)
     end
   },
   inputs: %{

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -75,4 +75,51 @@ defmodule Ch do
   def run(conn, f, opts \\ []) when is_function(f, 1) do
     DBConnection.run(conn, f, opts)
   end
+
+  for size <- [8, 16, 32, 64, 128, 256] do
+    @doc "UInt#{size} type helper"
+    def unquote(:"u#{size}")(), do: unquote(:"u#{size}")
+    @doc "Int#{size} type helper"
+    def unquote(:"i#{size}")(), do: unquote(:"i#{size}")
+  end
+
+  for size <- [32, 64] do
+    @doc "Float#{size} type helper"
+    def unquote(:"f#{size}")(), do: unquote(:"f#{size}")
+  end
+
+  @doc "UTF8 String type helper"
+  def string, do: :string
+  @doc "Binary type helper"
+  def binary, do: :binary
+  @doc "Boolean type helper"
+  def boolean, do: :boolean
+  @doc "Date type helper"
+  def date, do: :date
+  @doc "DateTime type helper"
+  def datetime, do: :datetime
+  @doc "Date32 type helper"
+  def date32, do: :date32
+  @doc "DateTime64(precision) type helper"
+  def datetime64(unit), do: {:datetime64, unit, nil}
+  @doc "UUID type helper"
+  def uuid, do: :uuid
+
+  # def datetime(tz) when is_binary(tz), do: {:datetime, tz}
+  # def datetime64(unit, timezone), do: {:datetime64, unit, nil}
+
+  @doc "FixedString(size) type helper"
+  def string(size) when is_integer(size) and size > 0, do: {:string, size}
+
+  for size <- [32, 64, 128, 256] do
+    @doc "Decimal#{size}(scale) type helper"
+    def unquote(:"decimal#{size}")(scale) when is_integer(scale) do
+      {:decimal, unquote(size), scale}
+    end
+  end
+
+  @doc "Array(T) type helper"
+  def array(type), do: {:array, type}
+  @doc "Nullable(T) type helper"
+  def nullable(type), do: {:nullable, type}
 end

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -11,7 +11,7 @@ defmodule Ch.ConnectionTest do
   end
 
   test "select with types", %{conn: conn} do
-    assert {:ok, %{num_rows: 1, rows: [[1]]}} = Ch.query(conn, "select 1", [], types: [:u8])
+    assert {:ok, %{num_rows: 1, rows: [[1]]}} = Ch.query(conn, "select 1", [], types: [Ch.u8()])
   end
 
   test "select with params", %{conn: conn} do
@@ -134,7 +134,7 @@ defmodule Ch.ConnectionTest do
 
     test "automatic RowBinary", %{conn: conn} do
       stmt = "insert into insert_t(a, b) format RowBinary"
-      types = [:u8, :string]
+      types = [Ch.u8(), Ch.string()]
       rows = [[1, "a"], [2, "b"]]
       assert %{num_rows: 2} = Ch.query!(conn, stmt, rows, types: types)
       assert %{rows: rows} = Ch.query!(conn, "select * from insert_t")
@@ -800,7 +800,7 @@ defmodule Ch.ConnectionTest do
       # TODO ensure flattened
       rows =
         Ch.run(conn, fn conn ->
-          Ch.stream(conn, stmt, _params = [], types: [:u64]) |> Enum.into([])
+          Ch.stream(conn, stmt, _params = [], types: [Ch.u64()]) |> Enum.into([])
         end)
 
       assert Enum.reject(rows, fn rows -> rows == [] end) == [

--- a/test/ch/faults_test.exs
+++ b/test/ch/faults_test.exs
@@ -337,7 +337,7 @@ defmodule Ch.FaultsTest do
 
       test = self()
       rows = [[1, 2], [3, 4]]
-      stream = Stream.map(rows, fn row -> Ch.RowBinary.encode_row(row, [:u8, :u8]) end)
+      stream = Stream.map(rows, fn row -> Ch.RowBinary.encode_row(row, [Ch.u8(), Ch.u8()]) end)
 
       log =
         capture_async_log(fn ->
@@ -389,7 +389,7 @@ defmodule Ch.FaultsTest do
 
       test = self()
       rows = [[1, 2], [3, 4]]
-      stream = Stream.map(rows, fn row -> Ch.RowBinary.encode_row(row, [:u8, :u8]) end)
+      stream = Stream.map(rows, fn row -> Ch.RowBinary.encode_row(row, [Ch.u8(), Ch.u8()]) end)
 
       log =
         capture_async_log(fn ->

--- a/test/ch/row_binary_test.exs
+++ b/test/ch/row_binary_test.exs
@@ -156,22 +156,22 @@ defmodule Ch.RowBinaryTest do
     assert bin == str
 
     # but decoding is different based on what type is provided
-    assert decode_rows(str, [:string]) == [["a�b"]]
-    assert decode_rows(bin, [:string]) == [["a�b"]]
-    assert decode_rows(str, [:binary]) == [["\x61\xF0\x80\x80\x80b"]]
-    assert decode_rows(bin, [:binary]) == [["\x61\xF0\x80\x80\x80b"]]
+    assert decode_rows(str, [Ch.string()]) == [["a�b"]]
+    assert decode_rows(bin, [Ch.string()]) == [["a�b"]]
+    assert decode_rows(str, [Ch.binary()]) == [["\x61\xF0\x80\x80\x80b"]]
+    assert decode_rows(bin, [Ch.binary()]) == [["\x61\xF0\x80\x80\x80b"]]
 
     path = "/some/url" <> <<0xAE>> <> "-/"
-    assert decode_rows(<<byte_size(path), path::bytes>>, [:string]) == [["/some/url�-/"]]
+    assert decode_rows(<<byte_size(path), path::bytes>>, [Ch.string()]) == [["/some/url�-/"]]
 
     path = <<0xAF>> <> "/some/url" <> <<0xAE, 0xFE>> <> "-/" <> <<0xFA>>
-    assert decode_rows(<<byte_size(path), path::bytes>>, [:string]) == [["�/some/url�-/�"]]
+    assert decode_rows(<<byte_size(path), path::bytes>>, [Ch.string()]) == [["�/some/url�-/�"]]
 
     path = "/opportunity/category/جوائز-ومسابقات"
-    assert decode_rows(<<byte_size(path), path::bytes>>, [:string]) == [[path]]
+    assert decode_rows(<<byte_size(path), path::bytes>>, [Ch.string()]) == [[path]]
 
     path = "/ﺝﻭﺎﺋﺯ-ﻮﻤﺳﺎﺒﻗﺎﺗ"
-    assert decode_rows(<<byte_size(path), path::bytes>>, [:string]) == [[path]]
+    assert decode_rows(<<byte_size(path), path::bytes>>, [Ch.string()]) == [[path]]
   end
 
   describe "decode_types/1" do
@@ -295,11 +295,11 @@ defmodule Ch.RowBinaryTest do
 
   describe "decode_rows/2" do
     test "empty" do
-      assert decode_rows(<<>>, [:u8, :string]) == []
+      assert decode_rows(<<>>, [Ch.u8(), Ch.string()]) == []
     end
 
     test "non-empty" do
-      assert decode_rows(<<1, 2>>, [:u8, :u8]) == [[1, 2]]
+      assert decode_rows(<<1, 2>>, [Ch.u8(), Ch.u8()]) == [[1, 2]]
     end
   end
 end


### PR DESCRIPTION
This PR adds functions that return atom types  for encoding. I think this would make type discovery easier for the users.

Before
```elixir
Ch.query(conn, "insert into table format RowBinary", rows, types: [:u32, {:array, {:string, 32}}, {:datetime64, :millisecond}])
```

After
```elixir
Ch.query(conn, "insert into table format RowBinary", rows, types: [Ch.u32, Ch.array(Ch.string(32)), Ch.datetime64(:millisecond)])
```

Supported types can now be "discovered" with `Ch.<TAB>`

- [ ] I am not sure if these helpers should go into the "root" namespace `Ch` or in `Ch.Types`. And if they go into `Ch`, should function names be prefixed with `type_` so that `Ch.type_<TAB>` lists only the type helpers.