### PR TITLE
replace {:raw, data} with encode: false, add :decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- replace `{:raw, data}` with `encode: false` option, add `:decode` option https://github.com/plausible/ch/pull/42
+
 ## 0.1.11 (2023-05-19)
 
 - improve Enum error message invalid values during encoding: https://github.com/plausible/ch/pull/85

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Ch.query!(pid, "CREATE TABLE IF NOT EXISTS ch_demo(id UInt64) ENGINE Null")
 csv = [0, 1] |> Enum.map(&to_string/1) |> Enum.intersperse(?\n)
 
 %Ch.Result{num_rows: 2} =
-  Ch.query!(pid, "INSERT INTO ch_demo(id) FORMAT CSV", {:raw, csv})
+  Ch.query!(pid, "INSERT INTO ch_demo(id) FORMAT CSV", csv, encode: false)
 ```
 
 #### Insert rows as chunked RowBinary stream
@@ -130,7 +130,7 @@ encoded = Stream.map(chunked, fn chunk -> Ch.RowBinary.encode_rows(chunk, _types
 ten_encoded_chunks = Stream.take(encoded, 10)
 
 %Ch.Result{num_rows: 1000} =
-  Ch.query(pid, "INSERT INTO ch_demo(id) FORMAT RowBinary", {:raw, ten_encoded_chunks})
+  Ch.query(pid, "INSERT INTO ch_demo(id) FORMAT RowBinary", ten_encoded_chunks, encode: false)
 ```
 
 This query makes a [`transfer-encoding: chunked`](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) HTTP request while unfolding the stream resulting in lower memory usage.

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -44,9 +44,9 @@ defmodule Ch do
   """
   @spec query(DBConnection.conn(), iodata, params, Keyword.t()) ::
           {:ok, Result.t()} | {:error, Exception.t()}
-        when raw: iodata | Enumerable.t(), params: map | [term] | [row :: [term]] | {:raw, raw}
+        when params: map | [term] | [row :: [term]] | iodata | Enumerable.t()
   def query(conn, statement, params \\ [], opts \\ []) do
-    query = Query.build(statement, Keyword.get(opts, :command))
+    query = Query.build(statement, opts)
 
     with {:ok, _query, result} <- DBConnection.execute(conn, query, params, opts) do
       {:ok, result}
@@ -58,16 +58,16 @@ defmodule Ch do
   there was an error. See `query/4`.
   """
   @spec query!(DBConnection.conn(), iodata, params, Keyword.t()) :: Result.t()
-        when raw: iodata | Enumerable.t(), params: map | [term] | [row :: [term]] | {:raw, raw}
+        when params: map | [term] | [row :: [term]] | iodata | Enumerable.t()
   def query!(conn, statement, params \\ [], opts \\ []) do
-    query = Query.build(statement, Keyword.get(opts, :command))
+    query = Query.build(statement, opts)
     DBConnection.execute!(conn, query, params, opts)
   end
 
   @doc false
   @spec stream(DBConnection.t(), iodata, map | [term], Keyword.t()) :: DBConnection.Stream.t()
   def stream(conn, statement, params \\ [], opts \\ []) do
-    query = Query.build(statement, Keyword.get(opts, :command))
+    query = Query.build(statement, opts)
     DBConnection.stream(conn, query, params, opts)
   end
 

--- a/test/ch/faults_test.exs
+++ b/test/ch/faults_test.exs
@@ -360,7 +360,8 @@ defmodule Ch.FaultsTest do
                      Ch.query(
                        conn,
                        "insert into unknown_table(a,b) format RowBinary",
-                       {:raw, stream}
+                       stream,
+                       encode: false
                      )
           end)
 
@@ -376,7 +377,8 @@ defmodule Ch.FaultsTest do
                      Ch.query(
                        conn,
                        "insert into unknown_table(a,b) format RowBinary",
-                       {:raw, stream}
+                       stream,
+                       encode: false
                      )
 
             assert message =~ ~r/UNKNOWN_TABLE/
@@ -417,7 +419,8 @@ defmodule Ch.FaultsTest do
                      Ch.query(
                        conn,
                        "insert into unknown_table(a,b) format RowBinary",
-                       {:raw, stream}
+                       stream,
+                       encode: false
                      )
           end)
 
@@ -437,7 +440,8 @@ defmodule Ch.FaultsTest do
                      Ch.query(
                        conn,
                        "insert into unknown_table(a,b) format RowBinary",
-                       {:raw, stream}
+                       stream,
+                       encode: false
                      )
 
             assert message =~ ~r/UNKNOWN_TABLE/

--- a/test/ch/query_test.exs
+++ b/test/ch/query_test.exs
@@ -30,11 +30,11 @@ defmodule Ch.QueryTest do
     end
 
     test "with nil command provided" do
-      assert Query.build("select 1+2", nil).command == :select
+      assert Query.build("select 1+2", command: nil).command == :select
     end
 
     test "with command provided" do
-      assert Query.build("select 1+2", :custom).command == :custom
+      assert Query.build("select 1+2", command: :custom).command == :custom
     end
 
     @tag skip: true


### PR DESCRIPTION
This PR adds `:encode` and `:decode` boolean options to `Ch.query`. `:encode` replaces `{:raw, data}` tuple. 

Before
```elixir
Ch.query(conn, "insert into table format CSV", {:raw, csv})
```
After
```elixir
Ch.query(conn, "insert into table format CSV", csv, encode: false)
```

`:decode` is new and allows skipping decoding even for "known" formats like RowBinary. It can be useful when operating on raw data (saving to disk, pushing to socket).