### PR TITLE
allow custom headers

### DIFF
--- a/test/ch/headers_test.exs
+++ b/test/ch/headers_test.exs
@@ -1,0 +1,56 @@
+defmodule Ch.HeadersTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    {:ok, conn} = Ch.start_link()
+    {:ok, conn: conn}
+  end
+
+  test "can request gzipped response through headers", %{conn: conn} do
+    assert {:ok, %{rows: rows, headers: headers}} =
+             Ch.query(conn, "select number from system.numbers limit 100", [],
+               decode: false,
+               settings: [enable_http_compression: 1],
+               headers: [{"accept-encoding", "gzip"}]
+             )
+
+    assert :proplists.get_value("content-type", headers) == "application/octet-stream"
+    assert :proplists.get_value("content-encoding", headers) == "gzip"
+    assert :proplists.get_value("x-clickhouse-format", headers) == "RowBinaryWithNamesAndTypes"
+
+    # https://en.wikipedia.org/wiki/Gzip
+    assert <<0x1F, 0x8B, _rest::bytes>> = IO.iodata_to_binary(rows)
+  end
+
+  test "can request lz4 response through headers", %{conn: conn} do
+    assert {:ok, %{rows: rows, headers: headers}} =
+             Ch.query(conn, "select number from system.numbers limit 100", [],
+               decode: false,
+               settings: [enable_http_compression: 1],
+               headers: [{"accept-encoding", "lz4"}]
+             )
+
+    assert :proplists.get_value("content-type", headers) == "application/octet-stream"
+    assert :proplists.get_value("content-encoding", headers) == "lz4"
+    assert :proplists.get_value("x-clickhouse-format", headers) == "RowBinaryWithNamesAndTypes"
+
+    # https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)
+    assert <<0x04, 0x22, 0x4D, 0x18, _rest::bytes>> = IO.iodata_to_binary(rows)
+  end
+
+  test "can request zstd response through headers", %{conn: conn} do
+    assert {:ok, %{rows: rows, headers: headers}} =
+             Ch.query(conn, "select number from system.numbers limit 100", [],
+               decode: false,
+               settings: [enable_http_compression: 1],
+               headers: [{"accept-encoding", "zstd"}]
+             )
+
+    assert :proplists.get_value("content-type", headers) == "application/octet-stream"
+    assert :proplists.get_value("content-encoding", headers) == "zstd"
+    assert :proplists.get_value("x-clickhouse-format", headers) == "RowBinaryWithNamesAndTypes"
+
+    # https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)
+    assert <<0x28, 0xB5, 0x2F, 0xFD, _rest::bytes>> = IO.iodata_to_binary(rows)
+  end
+end


### PR DESCRIPTION
Useful for fetching compressed responses, for example. https://clickhouse.com/docs/en/interfaces/http#compression

```elixir
iex> {:ok, conn} = Ch.start_link()
iex> Ch.query(
  conn,
  "select * from system.numbers limit 100",
  _params = [],
  format: "CSVWithNames",
  headers: [{"accept-encoding", "gzip"}],
  settings: [enable_http_compression: 1]
)
{:ok,
 %Ch.Result{
   command: :select,
   num_rows: nil,
   rows: [
     <<31, 139, 8, 0, 0, 0, 0, 0, 0, 3, 4, 193, 185, 77, 0, 64, 16, 4, 65, 191,
       195, 32, 130, 155, 157, 125, 211, 65, 194, 4, 3, 137, 252, 169, 250, 248,
       249, 251, 254, 252, 250, 253, 224, 33, ...>>
   ],
   headers: [
     {"date", "Wed, 25 Oct 2023 17:36:19 GMT"},
     {"connection", "Keep-Alive"},
     {"content-type", "text/csv; charset=UTF-8; header=present"},
     {"x-clickhouse-server-display-name", "c8f52f9cd86e"},
     {"transfer-encoding", "chunked"},
     {"x-clickhouse-query-id", "d341876d-edb4-4825-a965-008ab7b2f450"},
     {"x-clickhouse-format", "CSVWithNames"},
     {"x-clickhouse-timezone", "UTC"},
     {"keep-alive", "timeout=3"},
     {"content-encoding", "gzip"},
     {"x-clickhouse-summary",
      "{\"read_rows\":\"100\",\"read_bytes\":\"800\",\"written_rows\":\"0\",\"written_bytes\":\"0\",\"total_rows_to_read\":\"0\",\"result_rows\":\"0\",\"result_bytes\":\"0\"}"}
   ]
 }}
```