### PR TITLE
Fix DateTime with zero microseconds encoding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix query encoding for datetimes with zeroed microseconds `~U[****-**-** **:**:**.000000]` https://github.com/plausible/ch/pull/138
+
 ## 0.2.1 (2023-08-22)
 
 - fix array casts with `Ch` subtype https://github.com/plausible/ch/pull/118

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -208,7 +208,12 @@ defimpl DBConnection.Query, for: Ch.Query do
         unix = DateTime.to_unix(dt, size)
         seconds = div(unix, size)
         fractional = rem(unix, size)
-        IO.iodata_to_binary([Integer.to_string(seconds), ?.,  String.pad_leading(Integer.to_string(fractional), precision)])
+
+        IO.iodata_to_binary([
+          Integer.to_string(seconds),
+          ?.,
+          String.pad_leading(Integer.to_string(fractional), precision)
+        ])
 
       _ ->
         dt |> DateTime.to_unix(:second) |> Integer.to_string()

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -205,9 +205,10 @@ defimpl DBConnection.Query, for: Ch.Query do
     seconds = DateTime.to_unix(dt, :second)
 
     case microsecond do
-      {val, size} when size > 0 ->
-        size = round(:math.pow(10, size))
-        Float.to_string((seconds * size + val) / size)
+      {val, precision} when precision > 0 ->
+        size = round(:math.pow(10, precision))
+        unix_seconds_float = (seconds * size + val) / size
+        :erlang.float_to_binary(unix_seconds_float, decimals: precision)
 
       _ ->
         Integer.to_string(seconds)

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -146,7 +146,7 @@ defmodule Ch.ConnectionTest do
     # this test case guards against a previous bug where DateTimes with a microsecond value of 0 and precision > 0 would
     # get encoded as a val like "1.6095024e9" which ClickHouse would be unable to parse to a DateTime.
     utc = ~U[2021-01-01 12:00:00.000000Z]
-    naive = DateTime.to_naive(utc)
+    naive = utc |> DateTime.shift_zone!(Ch.Test.clickhouse_tz(conn)) |> DateTime.to_naive()
 
     assert Ch.query!(conn, "select {$0:DateTime64(6)} as d, toString(d)", [utc]).rows ==
              [[~N[2021-01-01 12:00:00.000000], to_string(naive)]]

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -140,13 +140,16 @@ defmodule Ch.ConnectionTest do
 
     assert Ch.query!(conn, "select {$0:DateTime64(6,'Europe/Moscow')} as d, toString(d)", [utc]).rows ==
              [[msk, "2021-01-01 15:00:00.123456"]]
+  end
 
-    # this test case gaurds against a previous bug where DateTimes with a microsecond value of 0 and precision > 0 would
-    # get encoded as a val like "1.6095024e9" which Clickhouse would be unable to parse to a DateTime.
-    utc_with_zero_microsec = ~U[2021-01-01 12:00:00.000000Z]
-    naive_with_zero_microsec = utc_with_zero_microsec |> DateTime.shift_zone!(Ch.Test.clickhouse_tz(conn)) |> DateTime.to_naive()
-    assert Ch.query!(conn, "select {$0:DateTime64(6)} as d, toString(d)", [utc_with_zero_microsec]).rows ==
-             [[~N[2021-01-01 12:00:00.000000], to_string(naive_with_zero_microsec)]]
+  test "utc datetime64 zero microseconds query param encoding", %{conn: conn} do
+    # this test case guards against a previous bug where DateTimes with a microsecond value of 0 and precision > 0 would
+    # get encoded as a val like "1.6095024e9" which ClickHouse would be unable to parse to a DateTime.
+    utc = ~U[2021-01-01 12:00:00.000000Z]
+    naive = DateTime.to_naive(utc)
+
+    assert Ch.query!(conn, "select {$0:DateTime64(6)} as d, toString(d)", [utc]).rows ==
+             [[~N[2021-01-01 12:00:00.000000], to_string(naive)]]
   end
 
   test "select with options", %{conn: conn} do

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -140,6 +140,13 @@ defmodule Ch.ConnectionTest do
 
     assert Ch.query!(conn, "select {$0:DateTime64(6,'Europe/Moscow')} as d, toString(d)", [utc]).rows ==
              [[msk, "2021-01-01 15:00:00.123456"]]
+
+    # this test case gaurds against a previous bug where DateTimes with a microsecond value of 0 and precision > 0 would
+    # get encoded as a val like "1.6095024e9" which Clickhouse would be unable to parse to a DateTime.
+    utc_with_zero_microsec = ~U[2021-01-01 12:00:00.000000Z]
+    naive_with_zero_microsec = utc_with_zero_microsec |> DateTime.shift_zone!(Ch.Test.clickhouse_tz(conn)) |> DateTime.to_naive()
+    assert Ch.query!(conn, "select {$0:DateTime64(6)} as d, toString(d)", [utc_with_zero_microsec]).rows ==
+             [[~N[2021-01-01 12:00:00.000000], to_string(naive_with_zero_microsec)]]
   end
 
   test "select with options", %{conn: conn} do


### PR DESCRIPTION
Hi, we've been adopting plausible's ch and ecto_ch packages and are super grateful for your open source work!

I noticed a bug where queries with elixir DateTime params that had microsecond precision with zero microseconds (e.g. `~U[2023-12-13 00:00:00.000000Z]`) would fail because the ch driver would encode them with a value like `1.6095024e9` which Clickhouse cannot parse.

`Float.to_string` returns the "shortest representation" possible, which in some cases will be scientific notation [[docs]](https://hexdocs.pm/elixir/1.12.3/Float.html#to_string/1).

There are a few ways to solve this but I chose to use `:erlang.float_to_binary` to prevent the scientific notation encoding.

Without the patch, the test case I added fails with:
```
** (Ch.Error) Code: 457. DB::Exception: Value 1.6095024e9 cannot be parsed as DateTime64(6) for query parameter '$0' because it isn't parsed completely: only 9 of 11 bytes was parsed: 1.6095024.
```

I'm not an expert in clickhouse or elixir so please let me know if you have any feedback or concerns! I'm happy to make any changes. Or feel free to make any changes yourself.

Thanks!