### PR TITLE
Experiment to simplify the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- simplify the API https://github.com/plausible/ch/pull/140
+  - move RowBinary to SQL statement
+  - improve timezone / datetime support
+  - automatically decode streams
+  - drop headers from `Ch.Result`
+  - allow custom headers
+
 ## 0.2.2 (2023-12-23)
 
 - fix query encoding for datetimes with zeroed microseconds `~U[****-**-** **:**:**.000000]` https://github.com/plausible/ch/pull/138

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -1,16 +1,16 @@
 defmodule Ch.Query do
   @moduledoc "Query struct wrapping the SQL statement."
-  defstruct [:statement, :command, :encode, :decode]
+  defstruct [:statement, :command, :decode]
 
-  @type t :: %__MODULE__{statement: iodata, command: atom, encode: boolean, decode: boolean}
+  @type t :: %__MODULE__{statement: Ch.statement(), command: command, decode: boolean}
+  @type params :: [{String.t(), String.t()}]
 
   @doc false
-  @spec build(iodata, Keyword.t()) :: t
+  @spec build(Ch.statement(), [Ch.option()]) :: t
   def build(statement, opts \\ []) do
     command = Keyword.get(opts, :command) || extract_command(statement)
-    encode = Keyword.get(opts, :encode, true)
     decode = Keyword.get(opts, :decode, true)
-    %__MODULE__{statement: statement, command: command, encode: encode, decode: decode}
+    %__MODULE__{statement: statement, command: command, decode: decode}
   end
 
   statements = [
@@ -43,6 +43,13 @@ defmodule Ch.Query do
     {"WATCH", :watch}
   ]
 
+  command_union =
+    statements
+    |> Enum.map(fn {_, command} -> command end)
+    |> Enum.reduce(&{:|, [], [&1, &2]})
+
+  @type command :: unquote(command_union)
+
   defp extract_command(statement)
 
   for {statement, command} <- statements do
@@ -54,8 +61,8 @@ defmodule Ch.Query do
     extract_command(rest)
   end
 
-  defp extract_command([first_segment | _] = statement) do
-    extract_command(first_segment) || extract_command(IO.iodata_to_binary(statement))
+  defp extract_command([first_segment | _]) do
+    extract_command(first_segment)
   end
 
   defp extract_command(_other), do: nil
@@ -64,117 +71,46 @@ end
 defimpl DBConnection.Query, for: Ch.Query do
   alias Ch.{Query, Result, RowBinary}
 
-  @spec parse(Query.t(), Keyword.t()) :: Query.t()
+  @spec parse(Query.t(), [Ch.option()]) :: Query.t()
   def parse(query, _opts), do: query
 
-  @spec describe(Query.t(), Keyword.t()) :: Query.t()
+  @spec describe(Query.t(), [Ch.option()]) :: Query.t()
   def describe(query, _opts), do: query
 
-  @spec encode(Query.t(), params, Keyword.t()) :: {query_params, Mint.Types.headers(), body}
-        when params: map | [term] | [row :: [term]] | iodata | Enumerable.t(),
-             query_params: [{String.t(), String.t()}],
-             body: iodata | Enumerable.t()
-
-  def encode(%Query{command: :insert, encode: false, statement: statement}, data, opts) do
-    body =
-      case data do
-        _ when is_list(data) or is_binary(data) -> [statement, ?\n | data]
-        _ -> Stream.concat([[statement, ?\n]], data)
-      end
-
-    {_query_params = [], headers(opts), body}
+  @spec encode(Query.t(), Ch.params(), [Ch.option()]) ::
+          {Ch.Query.params(), Mint.Types.headers(), Ch.statement()}
+  def encode(%Query{statement: statement}, params, opts) do
+    format = Keyword.get(opts, :format, "RowBinaryWithNamesAndTypes")
+    headers = Keyword.get(opts, :headers, [])
+    {query_params(params), [{"x-clickhouse-format", format} | headers], statement}
   end
 
-  def encode(%Query{command: :insert, statement: statement}, params, opts) do
-    cond do
-      names = Keyword.get(opts, :names) ->
-        types = Keyword.fetch!(opts, :types)
-        header = RowBinary.encode_names_and_types(names, types)
-        data = RowBinary.encode_rows(params, types)
-        {_query_params = [], headers(opts), [statement, ?\n, header | data]}
+  @spec decode(Query.t(), [response], [Ch.option()]) :: Result.t()
+        when response: Mint.Types.status() | Mint.Types.headers() | binary
+  def decode(%Query{command: command, decode: decode}, responses, _opts)
+      when is_list(responses) do
+    # TODO potentially fails on x-progress-headers
+    [_status, headers | data] = responses
+    format = get_header(headers, "x-clickhouse-format")
 
-      format_row_binary?(statement) ->
-        types = Keyword.fetch!(opts, :types)
-        data = RowBinary.encode_rows(params, types)
-        {_query_params = [], headers(opts), [statement, ?\n | data]}
+    cond do
+      decode and format == "RowBinaryWithNamesAndTypes" ->
+        rows = data |> IO.iodata_to_binary() |> RowBinary.decode_rows()
+        %Result{num_rows: length(rows), rows: rows, command: command}
+
+      format == nil ->
+        num_rows =
+          if summary = get_header(headers, "x-clickhouse-summary") do
+            %{"written_rows" => written_rows} = Jason.decode!(summary)
+            String.to_integer(written_rows)
+          end
+
+        %Result{num_rows: num_rows, command: command}
 
       true ->
-        {query_params(params), headers(opts), statement}
+        %Result{rows: data, command: command}
     end
   end
-
-  def encode(%Query{statement: statement}, params, opts) do
-    types = Keyword.get(opts, :types)
-    default_format = if types, do: "RowBinary", else: "RowBinaryWithNamesAndTypes"
-    format = Keyword.get(opts, :format) || default_format
-    {query_params(params), [{"x-clickhouse-format", format} | headers(opts)], statement}
-  end
-
-  defp format_row_binary?(statement) when is_binary(statement) do
-    statement |> String.trim_trailing() |> String.ends_with?("RowBinary")
-  end
-
-  defp format_row_binary?(statement) when is_list(statement) do
-    statement
-    |> IO.iodata_to_binary()
-    |> format_row_binary?()
-  end
-
-  @spec decode(Query.t(), [response], Keyword.t()) :: Result.t()
-        when response: Mint.Types.status() | Mint.Types.headers() | binary
-  def decode(%Query{command: :insert}, responses, _opts) do
-    [_status, headers | _data] = responses
-
-    num_rows =
-      if summary = get_header(headers, "x-clickhouse-summary") do
-        %{"written_rows" => written_rows} = Jason.decode!(summary)
-        String.to_integer(written_rows)
-      end
-
-    %Result{num_rows: num_rows, rows: nil, command: :insert, headers: headers}
-  end
-
-  def decode(%Query{decode: false, command: command}, responses, _opts) when is_list(responses) do
-    # TODO potentially fails on x-progress-headers
-    [_status, headers | data] = responses
-    %Result{rows: data, command: command, headers: headers}
-  end
-
-  def decode(%Query{command: command}, responses, opts) when is_list(responses) do
-    # TODO potentially fails on x-progress-headers
-    [_status, headers | data] = responses
-
-    case get_header(headers, "x-clickhouse-format") do
-      "RowBinary" ->
-        types = Keyword.fetch!(opts, :types)
-        rows = data |> IO.iodata_to_binary() |> RowBinary.decode_rows(types)
-        %Result{num_rows: length(rows), rows: rows, command: command, headers: headers}
-
-      "RowBinaryWithNamesAndTypes" ->
-        rows = data |> IO.iodata_to_binary() |> RowBinary.decode_rows()
-        %Result{num_rows: length(rows), rows: rows, command: command, headers: headers}
-
-      _other ->
-        %Result{rows: data, command: command, headers: headers}
-    end
-  end
-
-  # TODO merge :stream `decode/3` with "normal" `decode/3` clause above
-  @spec decode(Query.t(), {:stream, nil, responses}, Keyword.t()) :: responses
-        when responses: [Mint.Types.response()]
-  def decode(_query, {:stream, nil, responses}, _opts), do: responses
-
-  @spec decode(Query.t(), {:stream, [atom], [Mint.Types.response()]}, Keyword.t()) :: [[term]]
-  def decode(_query, {:stream, types, responses}, _opts) do
-    decode_stream_data(responses, types)
-  end
-
-  defp decode_stream_data([{:data, _ref, data} | rest], types) do
-    [RowBinary.decode_rows(data, types) | decode_stream_data(rest, types)]
-  end
-
-  defp decode_stream_data([_ | rest], types), do: decode_stream_data(rest, types)
-  defp decode_stream_data([] = done, _types), do: done
 
   defp get_header(headers, key) do
     case List.keyfind(headers, key, 0) do
@@ -183,15 +119,13 @@ defimpl DBConnection.Query, for: Ch.Query do
     end
   end
 
-  defp query_params(params) when is_map(params) do
-    Enum.map(params, fn {k, v} -> {"param_#{k}", encode_param(v)} end)
+  @compile inline: [query_params: 1]
+  defp query_params(params) do
+    Enum.map(params, &__MODULE__.query_param/1)
   end
 
-  defp query_params(params) when is_list(params) do
-    params
-    |> Enum.with_index()
-    |> Enum.map(fn {v, idx} -> {"param_$#{idx}", encode_param(v)} end)
-  end
+  @doc false
+  def query_param({k, v}), do: {"param_#{k}", encode_param(v)}
 
   defp encode_param(n) when is_integer(n), do: Integer.to_string(n)
   defp encode_param(f) when is_float(f), do: Float.to_string(f)
@@ -272,9 +206,6 @@ defimpl DBConnection.Query, for: Ch.Query do
   end
 
   defp escape_param([], param), do: param
-
-  @spec headers(Keyword.t()) :: Mint.Types.headers()
-  defp headers(opts), do: Keyword.get(opts, :headers, [])
 end
 
 defimpl String.Chars, for: Ch.Query do

--- a/lib/ch/result.ex
+++ b/lib/ch/result.ex
@@ -2,21 +2,19 @@ defmodule Ch.Result do
   @moduledoc """
   Result struct returned from any successful query. Its fields are:
 
-    * `command` - An atom of the query command, for example: `:select`, `:insert`;
+    * `command` - An atom of the query command, for example: `:select`, `:insert`
     * `rows` - The result set. One of:
       - a list of lists, each inner list corresponding to a
-        row, each element in the inner list corresponds to a column;
+        row, each element in the inner list corresponds to a column
       - raw iodata when the response is not automatically decoded, e.g. `x-clickhouse-format: CSV`
-    * `num_rows` - The number of fetched or affected rows;
-    * `headers` - The HTTP response headers
+    * `num_rows` - The number of fetched or affected rows
   """
 
   defstruct [:command, :num_rows, :rows, :headers]
 
   @type t :: %__MODULE__{
-          command: atom,
+          command: Ch.Query.command() | nil,
           num_rows: non_neg_integer | nil,
-          rows: [[term]] | iodata | nil,
-          headers: Mint.Types.headers()
+          rows: [[term]] | iodata | nil
         }
 end

--- a/lib/ch/result.ex
+++ b/lib/ch/result.ex
@@ -3,18 +3,19 @@ defmodule Ch.Result do
   Result struct returned from any successful query. Its fields are:
 
     * `command` - An atom of the query command, for example: `:select`, `:insert`
-    * `rows` - The result set. One of:
-      - a list of lists, each inner list corresponding to a
-        row, each element in the inner list corresponds to a column
-      - raw iodata when the response is not automatically decoded, e.g. `x-clickhouse-format: CSV`
     * `num_rows` - The number of fetched or affected rows
+    * `types` - The response types
+    * `rows` - A list of lists, each inner list corresponding to a row, each element in the inner list corresponds to a column
+    * `data` - The raw iodata from the response
   """
 
-  defstruct [:command, :num_rows, :rows, :headers]
+  defstruct [:command, :num_rows, :types, :rows, :data]
 
   @type t :: %__MODULE__{
           command: Ch.Query.command() | nil,
           num_rows: non_neg_integer | nil,
-          rows: [[term]] | iodata | nil
+          types: [term] | nil,
+          rows: [[term]] | nil,
+          data: iodata
         }
 end

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -443,31 +443,31 @@ defmodule Ch.RowBinary do
   defp d(?f), do: 15
 
   @doc """
-  Decodes [`RowBinaryWithNamesAndTypes`](https://clickhouse.com/docs/en/sql-reference/formats#rowbinarywithnamesandtypes) into rows.
+  Decodes [`RowBinaryWithNamesAndTypes`](https://clickhouse.com/docs/en/sql-reference/formats#rowbinarywithnamesandtypes)
 
   Example:
 
-      iex> decode_rows(<<1, 3, "1+1"::bytes, 5, "UInt8"::bytes, 2>>)
+      iex> decode_with_names_and_types(<<1, 3, "1+1"::bytes, 5, "UInt8"::bytes, 2>>)
       [[2]]
 
   """
-  def decode_rows(row_binary_with_names_and_types)
-  def decode_rows(<<cols, rest::bytes>>), do: skip_names(rest, cols, cols)
-  def decode_rows(<<>>), do: []
+  def decode_with_names_and_types(row_binary_with_names_and_types)
+  def decode_with_names_and_types(<<cols, rest::bytes>>), do: skip_names(rest, cols, cols)
+  def decode_with_names_and_types(<<>>), do: []
 
   @doc """
-  Decodes [`RowBinary`](https://clickhouse.com/docs/en/sql-reference/formats#rowbinary) into rows.
+  Decodes [`RowBinary`](https://clickhouse.com/docs/en/sql-reference/formats#rowbinary)
 
   Example:
 
-      iex> decode_rows(<<1>>, ["UInt8"])
+      iex> decode(<<1>>, _types = ["UInt8"])
       [[1]]
 
   """
-  def decode_rows(row_binary, types)
-  def decode_rows(<<>>, _types), do: []
+  def decode(row_binary, types)
+  def decode(<<>>, _types), do: []
 
-  def decode_rows(<<data::bytes>>, types) do
+  def decode(<<data::bytes>>, types) do
     types = decoding_types(types)
     decode_rows(types, data, [], [], types)
   end

--- a/test/ch/datetime_test.exs
+++ b/test/ch/datetime_test.exs
@@ -1,0 +1,83 @@
+# Note on datetime encoding in query parameters:
+
+# - `%NaiveDateTime{}` is encoded as text to make it assume the column's or ClickHouse's timezone
+
+# ```elixir
+# Mix.install([:ch, :tz])
+
+# {:ok, pid} = Ch.start_link()
+# naive = ~N[2023-12-16 12:00:00]
+
+# %Ch.Result{rows: [["UTC"]]} = Ch.query!(pid, "SELECT timezone()")
+
+# %Ch.Result{rows: [[~N[2023-12-16 12:00:00]]]} =
+#   Ch.query!(pid, "SELECT {naive:DateTime}", %{"naive" => naive})
+
+# # https://clickhouse.com/docs/en/operations/settings/settings#session_timezone
+# %Ch.Result{rows: [["Europe/Berlin"]]} =
+#   Ch.query!(pid, "SELECT timezone()", [], settings: [session_timezone: "Europe/Berlin"])
+
+# %Ch.Result{rows: [[~N[2023-12-16 11:00:00]]]} =
+#   Ch.query!(pid, "SELECT {naive:DateTime}", %{"naive" => naive}, settings: [session_timezone: "Europe/Berlin"])
+
+# :ok = Calendar.put_time_zone_database(Tz.TimeZoneDatabase)
+
+# %Ch.Result{rows: [[taipei]]} =
+#   Ch.query!(pid, "SELECT {naive:DateTime('Asia/Taipei')}", %{"naive" => naive})
+
+# "#DateTime<2023-12-16 12:00:00+08:00 CST Asia/Taipei>" = inspect(taipei)
+# ```
+
+# - `%DateTime{time_zone: "Etc/UTC"}` is encoded as unix timestamp and is treated as UTC timestamp by ClickHouse
+
+# ```elixir
+# {:ok, pid} = Ch.start_link()
+
+# ```
+
+# - encoding non-UTC `%DateTime{}` requires a timezone database be configured
+
+# ```elixir
+# Mix.install([:ch, :tz])
+
+# :ok = Calendar.put_time_zone_database(Tz.TimeZoneDatabase)
+
+# utc = ~U[2023-12-16 10:20:51Z]
+# taipei = DateTime.new!(~D[2023-12-16], ~T[18:20:51], "Asia/Taipei")
+# berlin = DateTime.new!(~D[2023-12-16], ~T[11:20:51], "Europe/Berlin")
+
+# %Ch.Result{rows: []} =
+#   Ch.query!(pid, "SELECT {utc:DateTime}", %{"utc" => utc})
+
+# %Ch.Result{rows: []} =
+#   Ch.query!(pid, "SELECT {taipei:DateTime}", %{"taipei" => taipei})
+
+# %Ch.Result{rows: []} =
+#   Ch.query!(pid, "SELECT {berlin:DateTime}", %{"berlin" => berlin})
+
+# %Ch.Result{rows: []} =
+#   Ch.query!(pid, "SELECT {utc:DateTime}", %{"utc" => utc}, settings: [session_timezone: "Europe/Berlin"])
+
+# %Ch.Result{rows: []} =
+#   Ch.query!(pid, "SELECT {taipei:DateTime('UTC')}", %{"ts" => taipei})
+
+# %Ch.Result{rows: []} =
+#   Ch.query!(pid, "SELECT {taipei:DateTime('Asia/Taipei')}", %{"ts" => taipei})
+
+# ```
+# Mix.install([:ch, :tz])
+
+# :ok = Calendar.put_time_zone_database(Tz.TimeZoneDatabase)
+
+# {:ok, pid} = Ch.start_link()
+
+# %Ch.Result{rows: [[~N[2023-04-25 17:45:09]]]} =
+#   Ch.query!(pid, "SELECT CAST(now() as DateTime)")
+
+# %Ch.Result{rows: [[~U[2023-04-25 17:45:11Z]]]} =
+#   Ch.query!(pid, "SELECT CAST(now() as DateTime('UTC'))")
+
+# %Ch.Result{rows: [[%DateTime{time_zone: "Asia/Taipei"} = taipei]]} =
+#   Ch.query!(pid, "SELECT CAST(now() as DateTime('Asia/Taipei'))")
+
+# "2023-04-26 01:45:12+08:00 CST Asia/Taipei" = to_string(taipei)


### PR DESCRIPTION
### Changes:

- improve timezone / datetime support

For RowBinary:
|clickhouse tz|app tz|value|result|
|-|-|-|-|
|any|any|`%DateTime{time_zone: "Etc/UTC"}`|dump to unix timestamp|
|any|any|`%DateTime{time_zone: "Asia/Taipei"}`|conversion into unix timestamp (this is slow)|
|UTC|UTC|`%NaiveDateTime{}`|dump to seconds = unix timestamp (correct)|
|Europe/Berlin|UTC|`%NaiveDateTime{}`|dump to seconds = unix timestamp (still correct)|
|Europe/Berlin|Asia/Taipei|`%NaiveDateTime{}`|dump to seconds != unix timestamp (incorrect, should raise?)|

For queries:
|clickhouse tz|app tz|datetime|
|-|-|-|

- automatically decode streams
  
```elixir
# decode by default (format=RowBinaryWithNamesAndTypes)
DBConnection.run(conn, fn conn ->
  Ch.stream(conn, "select * from numbers limit {limit:UInt64}", %{"limit" => 1_000_000})
  |> Stream.each(&IO.inspect/1)
  |> Stream.run()
end)
# %Ch.Result{rows: [[]], data: <<>>}
# %Ch.Result{rows: [[]], data: <<>>}
# %Ch.Result{rows: [[]], data: <<>>}

# don't decode unknown format
DBConnection.run(conn, fn conn ->
  Ch.stream(conn, "select * from numbers limit {limit:UInt64} format CSV", %{"limit" => 1_000_000})
  |> Stream.each(&IO.inspect/1)
  |> Stream.run()
end)
# %Ch.Result{rows: nil, data: ''}

# don't decode if `decode: false`
DBConnection.run(conn, fn conn ->
  Ch.stream(conn, "select * from numbers limit {limit:UInt64}", %{"limit" => 1_000_000}, decode: false)
  |> Stream.each(&IO.inspect/1)
  |> Stream.run()
end)
# %Ch.Result{rows: nil, data: <<>>}
```