### PR TITLE
Ch.Result: drop :headers, add :data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - move rows payload (RowBinary, CSV, etc.) to SQL statement and remove pseudo-positional binds, making param names explicit https://github.com/plausible/ch/pull/143
+- drop `:headers` from `%Ch.Result{}` but add `:data`
 
 ## 0.2.2 (2023-12-23)
 

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -94,7 +94,7 @@ defimpl DBConnection.Query, for: Ch.Query do
     cond do
       decode and format == "RowBinaryWithNamesAndTypes" ->
         rows = data |> IO.iodata_to_binary() |> RowBinary.decode_rows()
-        %Result{num_rows: length(rows), rows: rows, headers: headers, command: command}
+        %Result{num_rows: length(rows), rows: rows, data: data, command: command}
 
       format == nil ->
         num_rows =
@@ -103,10 +103,10 @@ defimpl DBConnection.Query, for: Ch.Query do
             String.to_integer(written_rows)
           end
 
-        %Result{num_rows: num_rows, headers: headers, command: command}
+        %Result{num_rows: num_rows, data: data, command: command}
 
       true ->
-        %Result{rows: data, headers: headers, command: command}
+        %Result{data: data, command: command}
     end
   end
 

--- a/lib/ch/result.ex
+++ b/lib/ch/result.ex
@@ -2,21 +2,19 @@ defmodule Ch.Result do
   @moduledoc """
   Result struct returned from any successful query. Its fields are:
 
-    * `command` - An atom of the query command, for example: `:select`, `:insert`;
-    * `rows` - The result set. One of:
-      - a list of lists, each inner list corresponding to a
-        row, each element in the inner list corresponds to a column;
-      - raw iodata when the response is not automatically decoded, e.g. `x-clickhouse-format: CSV`
-    * `num_rows` - The number of fetched or affected rows;
-    * `headers` - The HTTP response headers
+    * `command` - An atom of the query command, for example: `:select`, `:insert`
+    * `num_rows` - The number of fetched or affected rows
+    * `rows` - A list of lists, each inner list corresponding to a row, each element in the inner list corresponds to a column
+    * `data` - The raw iodata from the response
+
   """
 
-  defstruct [:command, :num_rows, :rows, :headers]
+  defstruct [:command, :num_rows, :rows, :data]
 
   @type t :: %__MODULE__{
-          command: atom,
+          command: Ch.Query.command() | nil,
           num_rows: non_neg_integer | nil,
-          rows: [[term]] | iodata | nil,
-          headers: Mint.Types.headers()
+          rows: [[term]] | nil,
+          data: iodata
         }
 end

--- a/test/ch/faults_test.exs
+++ b/test/ch/faults_test.exs
@@ -468,8 +468,7 @@ defmodule Ch.FaultsTest do
       test = self()
 
       header = "X-ClickHouse-Server-Display-Name"
-      {:ok, %Result{headers: headers}} = Ch.Test.sql_exec("select 1")
-      {_, expected_name} = List.keyfind!(headers, String.downcase(header), 0)
+      {:ok, %Result{rows: [[expected_name]]}} = Ch.Test.sql_exec("select hostName()")
 
       log =
         capture_async_log(fn ->

--- a/test/ch/headers_test.exs
+++ b/test/ch/headers_test.exs
@@ -7,50 +7,38 @@ defmodule Ch.HeadersTest do
   end
 
   test "can request gzipped response through headers", %{conn: conn} do
-    assert {:ok, %{rows: rows, headers: headers}} =
+    assert {:ok, %{data: data}} =
              Ch.query(conn, "select number from system.numbers limit 100", [],
                decode: false,
                settings: [enable_http_compression: 1],
                headers: [{"accept-encoding", "gzip"}]
              )
 
-    assert :proplists.get_value("content-type", headers) == "application/octet-stream"
-    assert :proplists.get_value("content-encoding", headers) == "gzip"
-    assert :proplists.get_value("x-clickhouse-format", headers) == "RowBinaryWithNamesAndTypes"
-
     # https://en.wikipedia.org/wiki/Gzip
-    assert <<0x1F, 0x8B, _rest::bytes>> = IO.iodata_to_binary(rows)
+    assert <<0x1F, 0x8B, _rest::bytes>> = IO.iodata_to_binary(data)
   end
 
   test "can request lz4 response through headers", %{conn: conn} do
-    assert {:ok, %{rows: rows, headers: headers}} =
+    assert {:ok, %{data: data}} =
              Ch.query(conn, "select number from system.numbers limit 100", [],
                decode: false,
                settings: [enable_http_compression: 1],
                headers: [{"accept-encoding", "lz4"}]
              )
 
-    assert :proplists.get_value("content-type", headers) == "application/octet-stream"
-    assert :proplists.get_value("content-encoding", headers) == "lz4"
-    assert :proplists.get_value("x-clickhouse-format", headers) == "RowBinaryWithNamesAndTypes"
-
     # https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)
-    assert <<0x04, 0x22, 0x4D, 0x18, _rest::bytes>> = IO.iodata_to_binary(rows)
+    assert <<0x04, 0x22, 0x4D, 0x18, _rest::bytes>> = IO.iodata_to_binary(data)
   end
 
   test "can request zstd response through headers", %{conn: conn} do
-    assert {:ok, %{rows: rows, headers: headers}} =
+    assert {:ok, %{data: data}} =
              Ch.query(conn, "select number from system.numbers limit 100", [],
                decode: false,
                settings: [enable_http_compression: 1],
                headers: [{"accept-encoding", "zstd"}]
              )
 
-    assert :proplists.get_value("content-type", headers) == "application/octet-stream"
-    assert :proplists.get_value("content-encoding", headers) == "zstd"
-    assert :proplists.get_value("x-clickhouse-format", headers) == "RowBinaryWithNamesAndTypes"
-
     # https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)
-    assert <<0x28, 0xB5, 0x2F, 0xFD, _rest::bytes>> = IO.iodata_to_binary(rows)
+    assert <<0x28, 0xB5, 0x2F, 0xFD, _rest::bytes>> = IO.iodata_to_binary(data)
   end
 end


### PR DESCRIPTION
`Ch.Result.data` makes it more explicit whether the rows have been automatically decoded or not.

`Ch.Result.headers` wasn't useful.