### PR TITLE
use ch/<version> as user-agent by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,4 @@ jobs:
       - run: mix deps.get --only $MIX_ENV
       - run: mix format --check-formatted
       - run: mix compile --warnings-as-errors
-      - run: mix test
+      - run: mix test --include slow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- use `ch-#{version}` as user-agent https://github.com/plausible/ch/pull/154
+
 ## 0.2.3 (2024-01-29)
 
 - fix socket leak on failed handshake https://github.com/plausible/ch/pull/153

--- a/test/ch/http_test.exs
+++ b/test/ch/http_test.exs
@@ -1,0 +1,50 @@
+defmodule Ch.HTTPTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :slow
+
+  describe "user-agent" do
+    setup do
+      {:ok, ch: start_supervised!(Ch)}
+    end
+
+    test "sets user-agent to ch/<version> by default", %{ch: ch} do
+      %Ch.Result{rows: [[123]], headers: resp_header} = Ch.query!(ch, "select 123")
+      {"x-clickhouse-query-id", query_id} = List.keyfind!(resp_header, "x-clickhouse-query-id", 0)
+      assert query_http_user_agent(ch, query_id) == "ch/0.2.3"
+    end
+
+    test "uses the provided user-agent", %{ch: ch} do
+      req_headers = [{"user-agent", "plausible/0.1.0"}]
+
+      %Ch.Result{rows: [[123]], headers: resp_header} =
+        Ch.query!(ch, "select 123", _params = [], headers: req_headers)
+
+      {"x-clickhouse-query-id", query_id} = List.keyfind!(resp_header, "x-clickhouse-query-id", 0)
+      assert query_http_user_agent(ch, query_id) == "plausible/0.1.0"
+    end
+  end
+
+  defp query_http_user_agent(ch, query_id) do
+    retry(fn ->
+      %Ch.Result{rows: [[user_agent]]} =
+        Ch.query!(
+          ch,
+          "select http_user_agent from system.query_log where query_id = {query_id:String} limit 1",
+          %{"query_id" => query_id}
+        )
+
+      user_agent
+    end)
+  end
+
+  defp retry(f) do
+    try do
+      f.()
+    catch
+      _, _ ->
+        :timer.sleep(100)
+        retry(f)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,4 +5,4 @@ default_test_db = System.get_env("CH_DATABASE", "ch_elixir_test")
 {:ok, _} = Ch.Test.sql_exec("CREATE DATABASE #{default_test_db}")
 Application.put_env(:ch, :database, default_test_db)
 
-ExUnit.start()
+ExUnit.start(exclude: [:slow])


### PR DESCRIPTION
```elixir
iex> {:ok, ch} = Ch.start_link
iex> Ch.query(ch, "select 123")
{:ok,
 %Ch.Result{
   headers: [
     # ...
     {"x-clickhouse-query-id", "45b902d1-f82d-4b47-8c9b-d985fa17c34e"},
     # ...
   ]
 }}
```

```sql
SELECT http_user_agent
FROM system.query_log
WHERE query_id = '45b902d1-f82d-4b47-8c9b-d985fa17c34e'
LIMIT 1

-- ┌─http_user_agent─┐
-- │ ch/0.2.3        │
-- └─────────────────┘
```