### PR TITLE
make Ch.stream collectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - add `:data` in `%Ch.Result{}` https://github.com/plausible/ch/pull/159
 - duplicate `Ch.Result.data` in `Ch.Result.rows` for backwards compatibility https://github.com/plausible/ch/pull/160
-- make `Ch.stream` emit `Ch.Result.t` instead of `Mint.Types.response`
+- make `Ch.stream` emit `Ch.Result.t` instead of `Mint.Types.response` https://github.com/plausible/ch/pull/161
+- make `Ch.stream` collectable https://github.com/plausible/ch/pull/162
 
 ## 0.2.4 (2024-01-29)
 

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -101,10 +101,10 @@ defmodule Ch do
   end
 
   @doc false
-  @spec stream(DBConnection.t(), iodata, map | [term], [query_option]) :: DBConnection.Stream.t()
+  @spec stream(DBConnection.t(), iodata, map | [term], [query_option]) :: Ch.Stream.t()
   def stream(conn, statement, params \\ [], opts \\ []) do
     query = Query.build(statement, opts)
-    DBConnection.stream(conn, query, params, opts)
+    %Ch.Stream{conn: conn, query: query, params: params, opts: opts}
   end
 
   # TODO drop

--- a/lib/ch/stream.ex
+++ b/lib/ch/stream.ex
@@ -1,0 +1,43 @@
+defmodule Ch.Stream do
+  @moduledoc false
+
+  @derive {Inspect, only: []}
+  defstruct [:conn, :ref, :query, :params, :opts]
+
+  @type t :: %__MODULE__{
+          conn: DBConnection.conn(),
+          ref: Mint.Types.request_ref() | nil,
+          query: Ch.Query.t(),
+          params: term,
+          opts: [Ch.query_option()]
+        }
+
+  defimpl Enumerable do
+    def reduce(stream, acc, fun) do
+      %Ch.Stream{conn: conn, query: query, params: params, opts: opts} = stream
+      stream = %DBConnection.Stream{conn: conn, query: query, params: params, opts: opts}
+      DBConnection.reduce(stream, acc, fun)
+    end
+
+    def member?(_, _), do: {:error, __MODULE__}
+    def count(_), do: {:error, __MODULE__}
+    def slice(_), do: {:error, __MODULE__}
+  end
+
+  defimpl Collectable do
+    def into(stream) do
+      %Ch.Stream{conn: conn, query: query, params: params, opts: opts} = stream
+      ref = DBConnection.execute!(conn, query, {:stream, params}, opts)
+      {%{stream | ref: ref}, &collect/2}
+    end
+
+    defp collect(%{conn: conn, query: query, ref: ref} = stream, {:cont, data}) do
+      ^ref = DBConnection.execute!(conn, query, {:stream, ref, data})
+      stream
+    end
+
+    defp collect(%{conn: conn, query: query, ref: ref}, eof) when eof in [:halt, :done] do
+      DBConnection.execute!(conn, query, {:stream, ref, :eof})
+    end
+  end
+end


### PR DESCRIPTION
This PR makes `Ch.Stream.t` collectable, meaning it can be `Enum.into`ed or `Stream.into`ed with iodata and that iodata will be sent as an HTTP chunk.

Example from https://github.com/plausible/analytics/pull/3692:

```elixir
  @doc """
  Creates a collectable stream which pipes the data to an `imported_*` table.

  Example usage:

      {:ok, pool} = Ch.start_link(pool_size: 1)

      DBConnection.run(pool, fn conn ->
        File.stream!("imported_browsers.csv", _64kb = 64000)
        |> Stream.into(import_stream(conn, _site_id = 12, _table = "imported_browsers", _format = "CSVWithNames"))
        |> Stream.run()
      end)

  """
  @spec import_stream(DBConnection.t(), pos_integer, String.t(), String.t(), [Ch.query_option()]) ::
          Ch.Stream.t()
  def import_stream(conn, site_id, table, format, opts \\ []) do
    :ok = ensure_supported_format(format)

    statement =
      [
        "INSERT INTO {table:Identifier} SELECT {site_id:UInt64} AS site_id, * FROM input('",
        input_structure(table),
        "') FORMAT ",
        format
      ]

    Ch.stream(conn, statement, %{"table" => table, "site_id" => site_id}, opts)
  end
```