### PR TITLE
fix: DateTime incorrectly encoded when microsecond precision > # digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix query encoding for datetimes where the microseconds value starts with zeroes `~U[****-**-** **:**:**.0*****]` https://github.com/plausible/ch/pull/175
+
 ## 0.2.5 (2024-03-05)
 
 - add `:data` in `%Ch.Result{}` https://github.com/plausible/ch/pull/159
@@ -10,7 +14,7 @@
 ## 0.2.4 (2024-01-29)
 
 - use `ch-#{version}` as user-agent https://github.com/plausible/ch/pull/154
-- fix query string escaping for `\t`, `\\`, and `\n` https://github.com/plausible/ch/pull/155 
+- fix query string escaping for `\t`, `\\`, and `\n` https://github.com/plausible/ch/pull/155
 
 ## 0.2.3 (2024-01-29)
 

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -232,7 +232,7 @@ defimpl DBConnection.Query, for: Ch.Query do
         IO.iodata_to_binary([
           Integer.to_string(seconds),
           ?.,
-          String.pad_leading(Integer.to_string(fractional), precision)
+          String.pad_leading(Integer.to_string(fractional), precision, "0")
         ])
 
       _ ->


### PR DESCRIPTION
@ruslandoga, I found this bug while investigating these errors in my application:
```
** (Ch.Error) Code: 457. DB::Exception: Value 1716753646. 99856 cannot be parsed as DateTime64 for query parameter '$6' because it isn't parsed completely: only 11 of 17 bytes was parsed: 1716753646. (BAD_QUERY_PARAMETER) (version 23.11.5.29 (official build))
```

I found a bug in our logic for encoding microsecond values. We left pad the value, but with the [default space parameter](https://hexdocs.pm/elixir/1.12/String.html#pad_leading/3) rather than a 0 😅. See the failing test in the first commit for the repro.
```
iex(23)> d
~U[2024-05-26 20:00:46.099856Z]
iex(24)> d.microsecond
{99856, 6}
```