### PR TITLE
Catch all errors in `connect/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- catch all errors in `connect/1` to avoid triggering Supervisor https://github.com/plausible/ch/pull/209
+
 ## 0.2.8 (2024-09-06)
 
 - support named tuples https://github.com/plausible/ch/pull/197

--- a/lib/ch/connection.ex
+++ b/lib/ch/connection.ex
@@ -50,6 +50,8 @@ defmodule Ch.Connection do
           {:error, reason}
       end
     end
+  catch
+    _kind, reason -> {:error, reason}
   end
 
   @impl true

--- a/test/ch/connect_test.exs
+++ b/test/ch/connect_test.exs
@@ -6,7 +6,7 @@ defmodule Ch.ConnectTest do
     {:ok, conn} =
       Ch.start_link(database: Ch.Test.database(), transport_opts: [sndbuf: nil])
 
-    :timer.sleep(:timer.seconds(5))
+    :timer.sleep(100)
 
     assert Process.alive?(conn)
   end

--- a/test/ch/connect_test.exs
+++ b/test/ch/connect_test.exs
@@ -1,6 +1,7 @@
 defmodule Ch.ConnectTest do
   use ExUnit.Case, async: true
 
+  @tag :slow
   test "retries to connect even with exceptions" do
     {:ok, conn} =
       Ch.start_link(database: Ch.Test.database(), transport_opts: [sndbuf: nil])

--- a/test/ch/connect_test.exs
+++ b/test/ch/connect_test.exs
@@ -1,13 +1,22 @@
 defmodule Ch.ConnectTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+  import ExUnit.CaptureLog
 
   @tag :slow
   test "retries to connect even with exceptions" do
-    {:ok, conn} =
-      Ch.start_link(database: Ch.Test.database(), transport_opts: [sndbuf: nil])
+    # See https://github.com/plausible/ch/issues/208
+    bad_transport_opts = [sndbuf: nil]
 
-    :timer.sleep(100)
+    logs =
+      capture_log(fn ->
+        {:ok, conn} =
+          Ch.start_link(database: Ch.Test.database(), transport_opts: bad_transport_opts)
 
-    assert Process.alive?(conn)
+        :timer.sleep(100)
+
+        assert Process.alive?(conn)
+      end)
+
+    assert logs =~ "failed to connect: ** (ArgumentError) argument error"
   end
 end

--- a/test/ch/connect_test.exs
+++ b/test/ch/connect_test.exs
@@ -1,0 +1,12 @@
+defmodule Ch.ConnectTest do
+  use ExUnit.Case, async: true
+
+  test "retries to connect even with exceptions" do
+    {:ok, conn} =
+      Ch.start_link(database: Ch.Test.database(), transport_opts: [sndbuf: nil])
+
+    :timer.sleep(:timer.seconds(5))
+
+    assert Process.alive?(conn)
+  end
+end


### PR DESCRIPTION
Context: #208 