### PR TITLE
CI | add :types to query_option so dialyzer is happy

### DIFF
--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -55,6 +55,7 @@ defmodule Ch do
           | {:command, Ch.Query.command()}
           | {:headers, [{String.t(), String.t()}]}
           | {:format, String.t()}
+          | {:types, [String.t()]}
           # TODO remove
           | {:encode, boolean}
           | {:decode, boolean}

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -55,7 +55,7 @@ defmodule Ch do
           | {:command, Ch.Query.command()}
           | {:headers, [{String.t(), String.t()}]}
           | {:format, String.t()}
-          | {:types, [String.t()]}
+          | {:types, [String.t() | atom | tuple]}
           # TODO remove
           | {:encode, boolean}
           | {:decode, boolean}


### PR DESCRIPTION
First, thank you for your awesome library!!

 I've just update it to last version and everything works except the CI, dialyzer fails because `:types` (opt needed when `RowBinary`) is not included in `query_option`

Before this commit dialyzer fails with:

```
The function call will not succeed.

Ch.query(_pid :: any(), _query :: <<_::8, _::size(1)>>, _events :: [map()], [
  {:types, [binary()]},
  ...
])

will never return since the success typing is:
(
  atom()
  | pid()
  | {atom(), _}
  | {:via, atom(), _}
  | %DBConnection{:conn_mode => _, :conn_ref => reference(), :pool_ref => _},
  binary()
  | maybe_improper_list(
      binary() | maybe_improper_list(any(), binary() | []) | byte(),
      binary() | []
    ),
  any(),
  [
    {:command
     | :database
     | :deadline
     | :decode
     | :encode
     | :format
     | :headers
     | :log
     | :password
     | :queue
     | :settings
     | :timeout
     | :username,
     atom() | binary() | (map() -> any()) | [{_, _}] | integer() | {atom(), atom(), [any()]}}
  ]
) :: {:error, %{:__exception__ => true, :__struct__ => atom(), atom() => _}} | {:ok, _}

and the contract is
(DBConnection.conn(), iodata(), params, [query_option()]) ::
  {:ok, Ch.Result.t()} | {:error, Exception.t()}
when params: map() | [term()] | [row :: [term()]] | iodata() | Enumerable.t()
```

now it is happy:
```
$ mix dialyzer
Finding suitable PLTs
Checking PLT...
[ :ch,  ...]
Looking up modules in dialyxir_erlang-26.0.2_elixir-1.15.4_deps-dev.plt
Finding applications for dialyxir_erlang-26.0.2_elixir-1.15.4_deps-dev.plt
Finding modules for dialyxir_erlang-26.0.2_elixir-1.15.4_deps-dev.plt
Checking 463 modules in dialyxir_erlang-26.0.2_elixir-1.15.4_deps-dev.plt
Adding 2013 modules to dialyxir_erlang-26.0.2_elixir-1.15.4_deps-dev.plt
done in 0m55.57s
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: ~c"/app/_build/dev/dialyxir_erlang-26.0.2_elixir-1.15.4_deps-dev.plt",
  files: [ ...],
  warnings: [:unknown]
]
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m5.36s
done (passed successfully)

```

I hope i didn't mess up somewhere 😄 