### PR TITLE
Allow queries to send parameters inside the body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ settings = [async_insert: 1]
 Ch.query!(pid, "CREATE TABLE IF NOT EXISTS ch_demo(id UInt64) ENGINE Null")
 
 {:ok, %Ch.Result{rows: [[0], [1], [2]]}} =
-  Ch.query(pid, "SELECT * FROM system.numbers LIMIT {$0:UInt8}", [3], params: :body)
+  Ch.query(pid, "SELECT * FROM system.numbers LIMIT {$0:UInt8}", [3], interpolate_params: true)
 
 {:ok, %Ch.Result{rows: [[0], [1], [2]]}} =
-  Ch.query(pid, "SELECT * FROM system.numbers LIMIT {limit:UInt8}", %{"limit" => 3}, params: :body)
+  Ch.query(pid, "SELECT * FROM system.numbers LIMIT {limit:UInt8}", %{"limit" => 3}, interpolate_params: true)
 
 %Ch.Result{num_rows: 2} =
-  Ch.query!(pid, "INSERT INTO ch_demo(id) VALUES ({$0:UInt8}), ({$1:UInt32})", [0, 1], params: :body)
+  Ch.query!(pid, "INSERT INTO ch_demo(id) VALUES ({$0:UInt8}), ({$1:UInt32})", [0, 1], interpolate_params: true)
 ```
 
 ## Caveats

--- a/README.md
+++ b/README.md
@@ -161,6 +161,26 @@ settings = [async_insert: 1]
   Ch.query!(pid, "SHOW SETTINGS LIKE 'async_insert'", [], settings: settings)
 ```
 
+#### Sending query params through the body
+
+> Use this if you want to interpolate your query params inside the body.
+> The URL will be empty.
+
+```elixir
+{:ok, pid} = Ch.start_link()
+
+Ch.query!(pid, "CREATE TABLE IF NOT EXISTS ch_demo(id UInt64) ENGINE Null")
+
+{:ok, %Ch.Result{rows: [[0], [1], [2]]}} =
+  Ch.query(pid, "SELECT * FROM system.numbers LIMIT {$0:UInt8}", [3], params: :body)
+
+{:ok, %Ch.Result{rows: [[0], [1], [2]]}} =
+  Ch.query(pid, "SELECT * FROM system.numbers LIMIT {limit:UInt8}", %{"limit" => 3}, params: :body)
+
+%Ch.Result{num_rows: 2} =
+  Ch.query!(pid, "INSERT INTO ch_demo(id) VALUES ({$0:UInt8}), ({$1:UInt32})", [0, 1], params: :body)
+```
+
 ## Caveats
 
 #### NULL in RowBinary

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -76,7 +76,7 @@ defmodule Ch do
     * `:headers` - Custom HTTP headers for the request
     * `:format` - Custom response format for the request
     * `:decode` - Whether to automatically decode the response
-    * `:encode_in_body` - Whether to encode the params in the query body
+    * `:interpolate_params` - Whether to interpolate params in the statement.
     * [`DBConnection.connection_option()`](https://hexdocs.pm/db_connection/DBConnection.html#t:connection_option/0)
 
   """

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -76,6 +76,7 @@ defmodule Ch do
     * `:headers` - Custom HTTP headers for the request
     * `:format` - Custom response format for the request
     * `:decode` - Whether to automatically decode the response
+    * `:encode_in_body` - Whether to encode the params in the query body
     * [`DBConnection.connection_option()`](https://hexdocs.pm/db_connection/DBConnection.html#t:connection_option/0)
 
   """

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -139,7 +139,7 @@ defimpl DBConnection.Query, for: Ch.Query do
     if Keyword.get(opts, :interpolate_params) do
       {[], headers, add_params_to_statement(params, statement)}
     else
-      {query_params(params), [{"x-clickhouse-format", format} | headers(opts)], statement}
+      {query_params(params), headers, statement}
     end
   end
 

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -122,7 +122,7 @@ defimpl DBConnection.Query, for: Ch.Query do
         data = RowBinary.encode_rows(params, types)
         {_query_params = [], headers(opts), [statement, ?\n | data]}
 
-      Keyword.get(opts, :encode_in_body) ->
+      Keyword.get(opts, :params) == :body ->
         {[], headers(opts), add_params_to_statement(params, statement)}
 
       true ->
@@ -136,7 +136,7 @@ defimpl DBConnection.Query, for: Ch.Query do
     format = Keyword.get(opts, :format) || default_format
     headers = [{"x-clickhouse-format", format} | headers(opts)]
 
-    if Keyword.get(opts, :encode_in_body) do
+    if Keyword.get(opts, :params) == :body do
       {[], headers, add_params_to_statement(params, statement)}
     else
       {query_params(params), [{"x-clickhouse-format", format} | headers(opts)], statement}

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -211,10 +211,9 @@ defimpl DBConnection.Query, for: Ch.Query do
 
   defp add_params_to_statement(params, statement) when is_map(params) do
     Enum.reduce(params, statement, fn {k, v}, statement ->
-      regex = ~r/\{\s*#{k}\s*(?::(?<type>[^}]+))?\s*\}/
-      captures = Regex.scan(regex, statement)
-
-      Enum.reduce(captures, statement, fn [_, type], statement ->
+      ~r/\{\s*#{k}\s*(?::(?<type>[^}]+))?\s*\}/
+      |> Regex.scan(statement)
+      |> Enum.reduce(statement, fn [_, type], statement ->
         escaped_type = Regex.escape(type)
         regex = ~r/\{\s*#{k}\s*:#{escaped_type}\s*\}/
         Regex.replace(regex, statement, encode_param_body(v, type))
@@ -226,10 +225,9 @@ defimpl DBConnection.Query, for: Ch.Query do
     params
     |> Enum.with_index()
     |> Enum.reduce(statement, fn {v, index}, statement ->
-      regex = ~r/\{\s*\$#{index}\s*(?::(?<type>[^}]+))?\s*\}/
-      captures = Regex.scan(regex, statement)
-
-      Enum.reduce(captures, statement, fn [_, type], statement ->
+      ~r/\{\s*\$#{index}\s*(?::(?<type>[^}]+))?\s*\}/
+      |> Regex.scan(statement)
+      |> Enum.reduce(statement, fn [_, type], statement ->
         escaped_type = Regex.escape(type)
         regex = ~r/\{\s*\$#{index}\s*:#{escaped_type}\s*\}/
         Regex.replace(regex, statement, encode_param_body(v, type))

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -122,7 +122,7 @@ defimpl DBConnection.Query, for: Ch.Query do
         data = RowBinary.encode_rows(params, types)
         {_query_params = [], headers(opts), [statement, ?\n | data]}
 
-      Keyword.get(opts, :params) == :body ->
+      Keyword.get(opts, :interpolate_params) ->
         {[], headers(opts), add_params_to_statement(params, statement)}
 
       true ->
@@ -136,7 +136,7 @@ defimpl DBConnection.Query, for: Ch.Query do
     format = Keyword.get(opts, :format) || default_format
     headers = [{"x-clickhouse-format", format} | headers(opts)]
 
-    if Keyword.get(opts, :params) == :body do
+    if Keyword.get(opts, :interpolate_params) do
       {[], headers, add_params_to_statement(params, statement)}
     else
       {query_params(params), [{"x-clickhouse-format", format} | headers(opts)], statement}

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -687,6 +687,12 @@ defmodule Ch.ConnectionTest do
                "map" => %{"pg" => 13, "hello" => 100}
              }).rows == [[%{"hello" => 100, "pg" => 13}]]
 
+      assert Ch.query!(conn, "select {map:Map(String, Map(Date, UInt8))}", %{
+               "map" => %{"pg" => %{~D[2022-01-01] => 13}, "hello" => %{~D[2022-01-02] => 100}}
+             }).rows == [
+               [%{"pg" => %{~D[2022-01-01] => 13}, "hello" => %{~D[2022-01-02] => 100}}]
+             ]
+
       Ch.query!(conn, "CREATE TABLE table_map (a Map(String, UInt64)) ENGINE=Memory")
 
       Ch.query!(


### PR DESCRIPTION
Some services don't allow large URLs (e.g. AWS when using ELBs has an 8k limit on the URL path), and since Ch always encodes params inside the body, sending a large params payload causes them to reject the URL with a 414 error.

This PR addresses this by accepting a new option `:interpolate_params` in `Ch.query/4` which replaces the Clickhouse param placeholders with the properly encoded parameters. This is done by switching the placeholder for a casting expression using `::`, so the return types are kept. Map types are a strange case so they are handled slightly differently. I also added a test for nested maps to ensure it works as intended.

To test this implementation, the best way to do it right now is to alter the conditions where the option is checked and run the tests. They all pass. If preferred, I can add a setting to optionally add this option to all queries or extra tests for this implementation, though for this to be worth it all queries should be tried with and without the option in my opinion.