### PR TITLE
add JSON type support (as text for now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - add [Time](https://clickhouse.com/docs/sql-reference/data-types/time) and [Time64](https://clickhouse.com/docs/sql-reference/data-types/time64) types support https://github.com/plausible/ch/pull/260
 - add [Variant](https://clickhouse.com/docs/sql-reference/data-types/variant) type support https://github.com/plausible/ch/pull/263
+- add [JSON](https://clickhouse.com/docs/sql-reference/data-types/newjson) type support https://github.com/plausible/ch/pull/262
 
 ## 0.4.1 (2025-07-07)
 

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -147,6 +147,7 @@ defmodule Ch do
     def cast(value, {:datetime64, _p}), do: Ecto.Type.cast(:naive_datetime_usec, value)
     def cast(value, {:datetime64, _p, "UTC"}), do: Ecto.Type.cast(:utc_datetime_usec, value)
     def cast(value, {:fixed_string, _s}), do: Ecto.Type.cast(:string, value)
+    def cast(value, :json), do: Ecto.Type.cast(:map, value)
 
     for size <- [8, 16, 32, 64, 128, 256] do
       def cast(value, unquote(:"i#{size}")), do: Ecto.Type.cast(:integer, value)

--- a/lib/ch/connection.ex
+++ b/lib/ch/connection.ex
@@ -429,13 +429,6 @@ defmodule Ch.Connection do
     scheme = String.to_existing_atom(opts[:scheme] || "http")
     address = opts[:hostname] || "localhost"
     port = opts[:port] || 8123
-    settings = opts[:settings] || []
-
-    settings =
-      settings
-      |> Keyword.put_new(:output_format_binary_write_json_as_string, 1)
-      |> Keyword.put_new(:input_format_binary_read_json_as_string, 1)
-
     mint_opts = [mode: :passive] ++ Keyword.take(opts, [:hostname, :transport_opts])
 
     with {:ok, conn} <- HTTP.connect(scheme, address, port, mint_opts) do
@@ -445,7 +438,7 @@ defmodule Ch.Connection do
         |> maybe_put_private(:database, opts[:database])
         |> maybe_put_private(:username, opts[:username])
         |> maybe_put_private(:password, opts[:password])
-        |> maybe_put_private(:settings, settings)
+        |> maybe_put_private(:settings, opts[:settings])
         |> maybe_put_private(:connect_options, opts)
 
       {:ok, conn}

--- a/lib/ch/connection.ex
+++ b/lib/ch/connection.ex
@@ -416,6 +416,13 @@ defmodule Ch.Connection do
     scheme = String.to_existing_atom(opts[:scheme] || "http")
     address = opts[:hostname] || "localhost"
     port = opts[:port] || 8123
+    settings = opts[:settings] || []
+
+    settings =
+      settings
+      |> Keyword.put_new(:output_format_binary_write_json_as_string, 1)
+      |> Keyword.put_new(:input_format_binary_read_json_as_string, 1)
+
     mint_opts = [mode: :passive] ++ Keyword.take(opts, [:hostname, :transport_opts])
 
     with {:ok, conn} <- HTTP.connect(scheme, address, port, mint_opts) do
@@ -425,7 +432,7 @@ defmodule Ch.Connection do
         |> maybe_put_private(:database, opts[:database])
         |> maybe_put_private(:username, opts[:username])
         |> maybe_put_private(:password, opts[:password])
-        |> maybe_put_private(:settings, opts[:settings])
+        |> maybe_put_private(:settings, settings)
         |> maybe_put_private(:connect_options, opts)
 
       {:ok, conn}

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -189,6 +189,9 @@ defmodule Ch.RowBinary do
   end
 
   def encode(:json, json) do
+    # assuming it can be sent as text and not "native" binary JSON
+    # i.e. assumes `settings: [input_format_binary_read_json_as_string: 1]`
+    # TODO
     encode(:string, Jason.encode_to_iodata!(json))
   end
 
@@ -905,6 +908,9 @@ defmodule Ch.RowBinary do
         decode_binary_decode_rows(bin, types_rest, row, rows, types)
 
       :json ->
+        # assuming it arrives as text and not "native" binary JSON
+        # i.e. assumes `settings: [output_format_binary_write_json_as_string: 1]`
+        # TODO
         decode_string_json_decode_rows(bin, types_rest, row, rows, types)
 
       # TODO utf8?

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -93,6 +93,7 @@ defmodule Ch.RowBinary do
        when t in [
               :string,
               :binary,
+              :json,
               :boolean,
               :uuid,
               :date,
@@ -185,6 +186,10 @@ defmodule Ch.RowBinary do
       _ when is_list(str) -> [encode(:varint, IO.iodata_length(str)) | str]
       nil -> 0
     end
+  end
+
+  def encode(:json, json) do
+    encode(:string, Jason.encode_to_iodata!(json))
   end
 
   def encode({:fixed_string, size}, str) when byte_size(str) == size do

--- a/lib/ch/types.ex
+++ b/lib/ch/types.ex
@@ -28,6 +28,7 @@ defmodule Ch.Types do
       {"Time", :time, []},
       {"Date32", :date32, []},
       {"Date", :date, []},
+      {"JSON", :json, []},
       {"LowCardinality", :low_cardinality, [:type]},
       for size <- [32, 64, 128, 256] do
         {"Decimal#{size}", :"decimal#{size}", [:int]}

--- a/lib/ch/types.ex
+++ b/lib/ch/types.ex
@@ -325,6 +325,7 @@ defmodule Ch.Types do
   end
 
   def decode("DateTime"), do: :datetime
+  def decode("JSON" <> _options), do: :json
 
   def decode(type) do
     try do

--- a/test/ch/faults_test.exs
+++ b/test/ch/faults_test.exs
@@ -69,7 +69,7 @@ defmodule Ch.FaultsTest do
 
           # failed handshake
           handshake = intercept_packets(mint)
-          assert handshake =~ "select 1"
+          assert handshake =~ "select 1, version()"
           :ok = :gen_tcp.send(clickhouse, handshake)
           :ok = :gen_tcp.send(mint, first_byte(intercept_packets(clickhouse)))
 
@@ -78,7 +78,7 @@ defmodule Ch.FaultsTest do
 
           # handshake
           handshake = intercept_packets(mint)
-          assert handshake =~ "select 1"
+          assert handshake =~ "select 1, version()"
           :ok = :gen_tcp.send(clickhouse, handshake)
           :ok = :gen_tcp.send(mint, intercept_packets(clickhouse))
         end)
@@ -96,7 +96,7 @@ defmodule Ch.FaultsTest do
 
           # failed handshake
           handshake = intercept_packets(mint)
-          assert handshake =~ "select 1"
+          assert handshake =~ "select 1, version()"
           :ok = :gen_tcp.send(clickhouse, handshake)
           :ok = :gen_tcp.send(mint, first_byte(intercept_packets(clickhouse)))
           :gen_tcp.close(mint)
@@ -106,7 +106,7 @@ defmodule Ch.FaultsTest do
 
           # handshake
           handshake = intercept_packets(mint)
-          assert handshake =~ "select 1"
+          assert handshake =~ "select 1, version()"
           :ok = :gen_tcp.send(clickhouse, handshake)
           :ok = :gen_tcp.send(mint, intercept_packets(clickhouse))
         end)
@@ -126,8 +126,8 @@ defmodule Ch.FaultsTest do
 
           # failed handshake
           handshake = intercept_packets(mint1)
-          assert handshake =~ "select 1"
-          altered_handshake = String.replace(handshake, "select 1", "select ;")
+          assert handshake =~ "select 1, version()"
+          altered_handshake = String.replace(handshake, "select 1", "select x")
           :ok = :gen_tcp.send(clickhouse, altered_handshake)
           :ok = :gen_tcp.send(mint1, intercept_packets(clickhouse))
 
@@ -136,7 +136,7 @@ defmodule Ch.FaultsTest do
 
           # handshake
           handshake = intercept_packets(mint2)
-          assert handshake =~ "select 1"
+          assert handshake =~ "select 1, version()"
           :ok = :gen_tcp.send(clickhouse, handshake)
           :ok = :gen_tcp.send(mint2, intercept_packets(clickhouse))
 
@@ -145,7 +145,7 @@ defmodule Ch.FaultsTest do
           assert Port.info(mint2)
         end)
 
-      assert log =~ "failed to connect: ** (Ch.Error) Code: 62. DB::Exception: Syntax error"
+      assert log =~ "UNKNOWN_IDENTIFIER"
     end
 
     test "reconnects after incorrect query result", ctx do
@@ -160,8 +160,11 @@ defmodule Ch.FaultsTest do
 
           # failed handshake
           handshake = intercept_packets(mint1)
-          assert handshake =~ "select 1"
-          altered_handshake = String.replace(handshake, "select 1", "select 2")
+          assert handshake =~ "select 1, version()"
+
+          altered_handshake =
+            String.replace(handshake, "select 1, version()", "select 2, version()")
+
           :ok = :gen_tcp.send(clickhouse, altered_handshake)
           :ok = :gen_tcp.send(mint1, intercept_packets(clickhouse))
 
@@ -170,7 +173,7 @@ defmodule Ch.FaultsTest do
 
           # handshake
           handshake = intercept_packets(mint2)
-          assert handshake =~ "select 1"
+          assert handshake =~ "select 1, version()"
           :ok = :gen_tcp.send(clickhouse, handshake)
           :ok = :gen_tcp.send(mint2, intercept_packets(clickhouse))
 
@@ -179,7 +182,7 @@ defmodule Ch.FaultsTest do
           assert Port.info(mint2)
         end)
 
-      assert log =~ "failed to connect: ** (Ch.Error) unexpected result for 'select 1'"
+      assert log =~ "failed to connect: ** (Ch.Error) unexpected result for 'select 1, version()'"
     end
   end
 

--- a/test/ch/json_test.exs
+++ b/test/ch/json_test.exs
@@ -1,0 +1,50 @@
+defmodule Ch.JSONTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :json
+
+  setup do
+    conn =
+      start_supervised!(
+        {Ch,
+         database: Ch.Test.database(),
+         settings: [
+           enable_json_type: 1,
+           output_format_binary_write_json_as_string: 1,
+           input_format_binary_read_json_as_string: 1
+         ]}
+      )
+
+    {:ok, conn: conn}
+  end
+
+  test "simple json", %{conn: conn} do
+    assert Ch.query!(conn, ~s|select '{"a":"b","c":"d"}'::json|).rows == [
+             [%{"a" => "b", "c" => "d"}]
+           ]
+
+    assert Ch.query!(conn, ~s|select '{"a":42}'::json|).rows == [[%{"a" => "42"}]]
+    assert Ch.query!(conn, ~s|select '{}'::json|).rows == [[%{}]]
+    assert Ch.query!(conn, ~s|select '{"a":null}'::json|).rows == [[%{}]]
+    assert Ch.query!(conn, ~s|select '{"a":3.14}'::json|).rows == [[%{"a" => 3.14}]]
+    assert Ch.query!(conn, ~s|select '{"a":true}'::json|).rows == [[%{"a" => true}]]
+    assert Ch.query!(conn, ~s|select '{"a":false}'::json|).rows == [[%{"a" => false}]]
+    assert Ch.query!(conn, ~s|select '{"a":{"b":"c"}}'::json|).rows == [[%{"a" => %{"b" => "c"}}]]
+
+    assert Ch.query!(conn, ~s|select '{"a":[]}'::json|).rows == [
+             [%{"a" => []}]
+           ]
+
+    assert Ch.query!(conn, ~s|select '{"a":[null]}'::json|).rows == [
+             [%{"a" => [nil]}]
+           ]
+
+    assert Ch.query!(conn, ~s|select '{"a":[1,3.14,"hello",null]}'::json|).rows == [
+             [%{"a" => ["1", "3.14", "hello", nil]}]
+           ]
+
+    assert Ch.query!(conn, ~s|select '{"a":[1,2.13,"s",{"a":"b"}]}'::json|).rows == [
+             [%{"a" => ["1", 2.13, "s", %{"a" => "b"}]}]
+           ]
+  end
+end

--- a/test/ch/json_test.exs
+++ b/test/ch/json_test.exs
@@ -4,22 +4,11 @@ defmodule Ch.JSONTest do
   @moduletag :json
 
   setup do
-    conn =
-      start_supervised!(
-        {Ch,
-         database: Ch.Test.database(),
-         settings: [
-           enable_json_type: 1,
-           output_format_binary_write_json_as_string: 1,
-           input_format_binary_read_json_as_string: 1
-         ]}
-      )
-
     on_exit(fn ->
       Ch.Test.query("DROP TABLE IF EXISTS test", [], database: Ch.Test.database())
     end)
 
-    {:ok, conn: conn}
+    {:ok, conn: start_supervised!({Ch, database: Ch.Test.database()})}
   end
 
   test "simple json", %{conn: conn} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -30,8 +30,8 @@ extra_exclude =
   if ch_version >= "25" do
     []
   else
-    # Time type is not supported in ClickHouse < 25
-    [:time]
+    # Time and JSON types are not supported in ClickHouse < 25
+    [:time, :json]
   end
 
 ExUnit.start(exclude: [:slow | extra_exclude])


### PR DESCRIPTION
closes https://github.com/plausible/ch/issues/218

This PR adds [JSON](https://clickhouse.com/docs/sql-reference/data-types/newjson) support by including `output_format_binary_write_json_as_string: 1` and `input_format_binary_read_json_as_string: 1` setting options in all requests in ClickHouse 24.10+.