### PR TITLE
allow null params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.3 (2025-07-21)
+## Unreleased
 
 - allow `nil` in params https://github.com/plausible/ch/pull/268
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3 (2025-07-21)
+
+- allow `nil` in params https://github.com/plausible/ch/pull/268
+
 ## 0.5.2 (2025-07-21)
 
 - make Dynamic usable in Ecto schemas https://github.com/plausible/ch/pull/267

--- a/lib/ch/query.ex
+++ b/lib/ch/query.ex
@@ -230,6 +230,7 @@ defimpl DBConnection.Query, for: Ch.Query do
   end
 
   defp encode_param(b) when is_boolean(b), do: Atom.to_string(b)
+  defp encode_param(nil), do: "\\N"
   defp encode_param(%Decimal{} = d), do: Decimal.to_string(d, :normal)
   defp encode_param(%Date{} = date), do: Date.to_iso8601(date)
   defp encode_param(%NaiveDateTime{} = naive), do: NaiveDateTime.to_iso8601(naive)
@@ -287,6 +288,8 @@ defimpl DBConnection.Query, for: Ch.Query do
   defp encode_array_param(s) when is_binary(s) do
     [?', escape_param([{"'", "''"}, {"\\", "\\\\"}], s), ?']
   end
+
+  defp encode_array_param(nil), do: "'\\N'"
 
   defp encode_array_param(%s{} = param) when s in [Date, NaiveDateTime] do
     [?', encode_param(param), ?']

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -23,6 +23,9 @@ defmodule Ch.ConnectionTest do
     assert {:ok, %{num_rows: 1, rows: [[false]]}} =
              Ch.query(conn, "select {b:Bool}", %{"b" => false})
 
+    assert {:ok, %{num_rows: 1, rows: [[nil]]}} =
+             Ch.query(conn, "select {n:Nullable(Nothing)}", %{"n" => nil})
+
     assert {:ok, %{num_rows: 1, rows: [[1.0]]}} =
              Ch.query(conn, "select {a:Float32}", %{"a" => 1.0})
 
@@ -37,6 +40,13 @@ defmodule Ch.ConnectionTest do
 
     assert {:ok, %{num_rows: 1, rows: [[["a\tb"]]]}} =
              Ch.query(conn, "select {a:Array(String)}", %{"a" => ["a\tb"]})
+
+    assert {:ok, %{num_rows: 1, rows: [[[true, false]]]}} =
+             Ch.query(conn, "select {a:Array(Bool)}", %{"a" => [true, false]})
+
+    # TODO why "" and not nil?
+    assert {:ok, %{num_rows: 1, rows: [[["a", "", "b"]]]}} =
+             Ch.query(conn, "select {a:Array(Nullable(String))}", %{"a" => ["a", nil, "b"]})
 
     assert {:ok, %{num_rows: 1, rows: [row]}} =
              Ch.query(conn, "select {a:Decimal(9,4)}", %{"a" => Decimal.new("2000.333")})


### PR DESCRIPTION
This PR allows passing `nil` in query params.