### PR TITLE
Raise an exception when reconnection fails

### DIFF
--- a/lib/ch/connection.ex
+++ b/lib/ch/connection.ex
@@ -420,7 +420,9 @@ defmodule Ch.Connection do
         # copy settings that are set dynamically (e.g. json as text) over to the new connection
         maybe_put_private(new_conn, :settings, HTTP.get_private(conn, :settings))
       else
-        _ -> conn
+        {:error, error} ->
+          Logger.warning("Could not reconnect due to #{inspect(error)}")
+          raise DBConnection.ConnectionError, "Reconnection failed: #{inspect(error)}"
       end
     end
   end


### PR DESCRIPTION
This hopefully prevents the situation in which an unusable (e.g. closed) connection is returned to the pool, causing the next client in queue fail to execute its query.

The expectation is, by propagating the `DBConnection.ConnectionError` we'll make it caught by DBConnection and the broken connection will be removed from the pool.

@ruslandoga curious on your thoughts on this