### PR TITLE
Fix encode_param for DateTime

### DIFF
--- a/test/ch/query_test.exs
+++ b/test/ch/query_test.exs
@@ -454,6 +454,49 @@ defmodule Ch.QueryTest do
       # assert [[[1, nil, 3]]] = Ch.query!(conn, "SELECT {$0:Array(integer)}", [[1, nil, 3]], query_options).rows
     end
 
+    test "encode datetimes close to unix epoch", %{conn: conn, query_options: query_options} do
+      assert [[~U[1970-01-01 00:00:00Z]]] ==
+               Ch.query!(
+                 conn,
+                 "SELECT {$0:DateTime('UTC')}",
+                 [~U[1970-01-01 00:00:00Z]],
+                 query_options
+               ).rows
+
+      assert [[~U[1970-01-01 00:00:00.001Z]]] ==
+               Ch.query!(
+                 conn,
+                 "SELECT {$0:DateTime64(3, 'UTC')}",
+                 [~U[1970-01-01 00:00:00.001Z]],
+                 query_options
+               ).rows
+
+      assert [[~U[1969-12-31 23:59:59Z]]] ==
+               Ch.query!(
+                 conn,
+                 "SELECT {$0:DateTime64(0, 'UTC')}",
+                 [~U[1969-12-31 23:59:59Z]],
+                 query_options
+               ).rows
+
+      # This is currently blocked on https://github.com/ClickHouse/ClickHouse/issues/96745
+      # assert [[~U[1969-12-31 23:59:59.500Z]]] ==
+      #          Ch.query!(
+      #            conn,
+      #            "SELECT {$0:DateTime64(3, 'UTC')}",
+      #            [~U[1969-12-31 23:59:59.500Z]],
+      #            query_options
+      #          ).rows
+
+      assert [[~U[1969-12-31 23:59:58.500Z]]] ==
+               Ch.query!(
+                 conn,
+                 "SELECT {$0:DateTime64(3, 'UTC')}",
+                 [~U[1969-12-31 23:59:58.500Z]],
+                 query_options
+               ).rows
+    end
+
     test "encode network types", %{conn: conn, query_options: query_options} do
       # TODO, or wrap in custom struct like in postgrex
       # assert [["127.0.0.1/32"]] =


### PR DESCRIPTION
I noticed that DateTime params close to epoch weren't encoded correctly, resulting in a query error. The reason is this bug report, which won't be fixed: https://github.com/ClickHouse/ClickHouse/issues/64708

As a workaround, I pad the encoded seconds with leading zeros, taking special care to not break in the case of negative values.

This actually lead to the discovery of another bug, https://github.com/ClickHouse/ClickHouse/issues/96745. We can wait for initial feedback on that one before we commit (and either fixate the unexpected behavior in the test or not).

I noticed that NaiveDataTime always uses ISO 8601 format, is there a specific reason for this or should we unify the encoding of both data types?