### PR TITLE
Add support for JSON type options

### DIFF
--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -156,6 +156,7 @@ defmodule Ch do
     def cast(value, {:datetime64, _p, "UTC"}), do: Ecto.Type.cast(:utc_datetime_usec, value)
     def cast(value, {:fixed_string, _s}), do: Ecto.Type.cast(:string, value)
     def cast(value, :json), do: Ecto.Type.cast(:map, value)
+    def cast(value, {:json, _opts}), do: Ecto.Type.cast(:map, value)
     def cast(value, :dynamic), do: {:ok, value}
 
     for size <- [8, 16, 32, 64, 128, 256] do

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -174,6 +174,7 @@ defmodule Ch.RowBinary do
   defp encoding_type(:ring), do: {:array, :point}
   defp encoding_type(:polygon), do: {:array, {:array, :point}}
   defp encoding_type(:multipolygon), do: {:array, {:array, {:array, :point}}}
+  defp encoding_type({:json, opts}), do: {:json, opts}
 
   defp encoding_type(type) do
     raise ArgumentError, "unsupported type for encoding: #{inspect(type)}"
@@ -194,6 +195,13 @@ defmodule Ch.RowBinary do
   end
 
   def encode(:json, json) do
+    # assuming it can be sent as text and not "native" binary JSON
+    # i.e. assumes `settings: [input_format_binary_read_json_as_string: 1]`
+    # TODO
+    encode(:string, Jason.encode_to_iodata!(json))
+  end
+
+  def encode({:json, _opts}, json) do
     # assuming it can be sent as text and not "native" binary JSON
     # i.e. assumes `settings: [input_format_binary_read_json_as_string: 1]`
     # TODO
@@ -773,6 +781,7 @@ defmodule Ch.RowBinary do
   defp decoding_type(:ring), do: {:array, :point}
   defp decoding_type(:polygon), do: {:array, {:array, :point}}
   defp decoding_type(:multipolygon), do: {:array, {:array, {:array, :point}}}
+  defp decoding_type({:json, _opts}), do: :json
 
   defp decoding_type(type) do
     raise ArgumentError, "unsupported type for decoding: #{inspect(type)}"

--- a/lib/ch/types.ex
+++ b/lib/ch/types.ex
@@ -68,6 +68,8 @@ defmodule Ch.Types do
     def unquote(name)(), do: unquote(name)
   end
 
+  def json(opts), do: {:json, opts}
+
   @doc """
   Helper for `DateTime` ClickHouse type:
 
@@ -359,7 +361,25 @@ defmodule Ch.Types do
 
   def decode("DateTime"), do: :datetime
   def decode("Dynamic"), do: :dynamic
-  def decode("JSON" <> _options), do: :json
+
+  def decode("JSON" <> options) do
+    case String.trim(options) do
+      "" ->
+        :json
+
+      "(" <> rest ->
+        opts =
+          rest
+          |> String.trim_trailing(")")
+          |> String.split(",")
+          |> Enum.map(&String.trim/1)
+
+        {settings, rest} = Enum.split_with(opts, &String.contains?(&1, "="))
+        {skips, type_hints} = Enum.split_with(rest, &String.match?(&1, ~r/^SKIP\s+/i))
+
+        {:json, [settings: settings, type_hints: Enum.sort(type_hints), skips: skips]}
+    end
+  end
 
   def decode(type) do
     try do
@@ -576,6 +596,19 @@ defmodule Ch.Types do
 
   for {encoded, decoded, []} <- types do
     def encode(unquote(decoded)), do: unquote(encoded)
+  end
+
+  def encode({:json, opts}) do
+    opts =
+      [
+        opts[:settings],
+        Enum.sort(opts[:type_hints] || []),
+        opts[:skips] || []
+      ]
+      |> List.flatten()
+      |> Enum.intersperse(", ")
+
+    ["JSON(", opts, ?)]
   end
 
   def encode(:datetime), do: "DateTime"

--- a/lib/ch/types.ex
+++ b/lib/ch/types.ex
@@ -363,22 +363,18 @@ defmodule Ch.Types do
   def decode("Dynamic"), do: :dynamic
 
   def decode("JSON" <> options) do
-    case String.trim(options) do
-      "" ->
-        :json
+    opts =
+      options
+      |> String.trim()
+      |> String.trim_leading("(")
+      |> String.trim_trailing(")")
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
 
-      "(" <> rest ->
-        opts =
-          rest
-          |> String.trim_trailing(")")
-          |> String.split(",")
-          |> Enum.map(&String.trim/1)
+    {settings, rest} = Enum.split_with(opts, &String.contains?(&1, "="))
+    {skips, type_hints} = Enum.split_with(rest, &String.match?(&1, ~r/^SKIP\s+/i))
 
-        {settings, rest} = Enum.split_with(opts, &String.contains?(&1, "="))
-        {skips, type_hints} = Enum.split_with(rest, &String.match?(&1, ~r/^SKIP\s+/i))
-
-        {:json, [settings: settings, type_hints: Enum.sort(type_hints), skips: skips]}
-    end
+    {:json, [settings: settings, type_hints: Enum.sort(type_hints), skips: skips]}
   end
 
   def decode(type) do

--- a/test/ch/json_test.exs
+++ b/test/ch/json_test.exs
@@ -1,6 +1,11 @@
 defmodule Ch.JSONTest do
   use ExUnit.Case, parameterize: [%{query_options: []}, %{query_options: [multipart: true]}]
 
+  import Ch.Test,
+    only: [
+      parameterize_query: 4
+    ]
+
   @moduletag :json
 
   setup ctx do
@@ -358,5 +363,51 @@ defmodule Ch.JSONTest do
         query_options
       )
     end
+  end
+
+  test "insert with settings, type hints and skip directives", %{
+    conn: conn,
+    query_options: query_options
+  } do
+    Ch.query!(
+      conn,
+      "CREATE TABLE json_test
+      (
+        `json` JSON(
+                max_dynamic_types=254,
+                max_dynamic_paths=10000,
+                name String,
+                age UInt8,
+                SKIP pass.body_part,
+                SKIP REGEXP 't.*'
+              )
+      ) ENGINE = Memory",
+      [],
+      query_options
+    )
+
+    stmt = "INSERT INTO json_test FORMAT RowBinaryWithNamesAndTypes"
+    rows = [[%{name: "John", age: 30, pass: %{body_part: "none"}, t: %{foo: "bar"}}]]
+    names = ["json"]
+
+    opts = [
+      names: names,
+      types: [
+        Ch.Types.decode("""
+        JSON(
+          max_dynamic_types=254,
+          max_dynamic_paths=10000,
+          age UInt8, name String,
+          SKIP `pass.body_part`,
+          SKIP REGEXP 't.*'
+        )
+        """)
+      ]
+    ]
+
+    assert {:ok, %Ch.Result{}} = parameterize_query(%{conn: conn}, stmt, rows, opts)
+
+    [[value]] = Ch.query!(conn, "select * from json_test", [], query_options).rows
+    assert value == %{"age" => 30, "name" => "John"}
   end
 end

--- a/test/ch/types_test.exs
+++ b/test/ch/types_test.exs
@@ -1,6 +1,6 @@
 defmodule Ch.TypesTest do
   use ExUnit.Case, async: true
-  import Ch.Types, only: [decode: 1]
+  import Ch.Types, only: [decode: 1, encode: 1, json: 1]
   doctest Ch.Types, import: true
 
   describe "decode/1" do
@@ -108,7 +108,30 @@ defmodule Ch.TypesTest do
       assert decode("JSON") == :json
       assert decode(" JSON ") == :json
 
-      # TODO JSON(...)
+      assert decode("JSON(max_dynamic_types=10)") ==
+               {:json, [settings: ["max_dynamic_types=10"], type_hints: [], skips: []]}
+
+      assert decode("JSON(age UInt8, name String)") ==
+               {:json, [settings: [], type_hints: ["age UInt8", "name String"], skips: []]}
+
+      assert decode("JSON(name String, age UInt8)") ==
+               {:json, [settings: [], type_hints: ["age UInt8", "name String"], skips: []]}
+
+      assert decode("JSON(SKIP a.e)") ==
+               {:json, [settings: [], type_hints: [], skips: ["SKIP a.e"]]}
+
+      assert decode("JSON(max_dynamic_types=10, name String, age UInt8, SKIP a.e)") ==
+               {:json,
+                [
+                  settings: ["max_dynamic_types=10"],
+                  type_hints: ["age UInt8", "name String"],
+                  skips: ["SKIP a.e"]
+                ]}
+
+      opts = [settings: ["max_dynamic_types=10"], type_hints: ["age UInt8"], skips: []]
+      assert json(opts) == {:json, opts}
+
+      assert to_string(encode(json(opts))) == "JSON(max_dynamic_types=10, age UInt8)"
     end
 
     test "datetime" do


### PR DESCRIPTION
Parse JSON(...) options into {:json, opts} with settings, type_hints and skips, and encode them back to "JSON(...)". Handle {:json, opts} in Ch.Types, Ch.RowBinary (encode/decoding) and Ch.cast. Add tests covering settings, type hints and skip directives for RowBinary insertion.

#308 