### PR TITLE
use DateTime.to_unix + DateTime.to_naive for naive datetime decoding in RowBinary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for `JSON(...)` (JSON with options) type https://github.com/plausible/ch/pull/309
 - RowBinary: de- and encode dynamic JSON https://github.com/plausible/ch/pull/296
 - use gregorian seconds for naive datetime encoding in rowbinary (it's faster this way) https://github.com/plausible/ch/pull/311
+- use `DateTime.to_unix/2` + `DateTime.to_naive/1` for naive datetime decoding in RowBinary https://github.com/plausible/ch/pull/313
 
 ## 0.7.1 (2026-01-15)
 

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -1461,11 +1461,13 @@ defmodule Ch.RowBinary do
       {:datetime, timezone} ->
         case bin do
           <<s::32-little, bin::bytes>> ->
+            dt = DateTime.from_unix!(s)
+
             dt =
               case timezone do
-                nil -> NaiveDateTime.add(@epoch_naive_datetime, s)
-                "UTC" -> DateTime.from_unix!(s)
-                _ -> s |> DateTime.from_unix!() |> DateTime.shift_zone!(timezone)
+                nil -> DateTime.to_naive(dt)
+                "UTC" -> dt
+                _ -> DateTime.shift_zone!(dt, timezone)
               end
 
             decode_rows(types_rest, bin, [dt | row], rows, types)
@@ -1538,20 +1540,13 @@ defmodule Ch.RowBinary do
       {:datetime64, time_unit, timezone} ->
         case bin do
           <<s::64-little-signed, bin::bytes>> ->
+            dt = DateTime.from_unix!(s, time_unit)
+
             dt =
               case timezone do
-                nil ->
-                  @epoch_naive_datetime
-                  |> NaiveDateTime.add(s, time_unit)
-                  |> truncate(time_unit)
-
-                "UTC" ->
-                  DateTime.from_unix!(s, time_unit)
-
-                _ ->
-                  s
-                  |> DateTime.from_unix!(time_unit)
-                  |> DateTime.shift_zone!(timezone)
+                nil -> DateTime.to_naive(dt)
+                "UTC" -> dt
+                _ -> DateTime.shift_zone!(dt, timezone)
               end
 
             decode_rows(types_rest, bin, [dt | row], rows, types)
@@ -1619,16 +1614,11 @@ defmodule Ch.RowBinary do
     end
   end
 
-  @compile inline: [time_unit: 1, time_prec: 1]
+  @compile inline: [time_unit: 1]
   for precision <- 0..9 do
     time_unit = round(:math.pow(10, precision))
 
     defp time_unit(unquote(precision)), do: unquote(time_unit)
-    defp time_prec(unquote(time_unit)), do: unquote(precision)
-  end
-
-  defp truncate(%{microsecond: {micros, _prec}} = date, time_unit) do
-    %{date | microsecond: {micros, time_prec(time_unit)}}
   end
 
   @compile inline: [time_after_midnight: 2]


### PR DESCRIPTION
This way we don't need to manually manipulate `microsecond: {microseconds, precision}` field.

The end result is similar to https://github.com/plausible/ch/pull/297