### PR TITLE
Cleanup `DateTime.t` encoding in RowBinary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - RowBinary: de- and encode dynamic JSON https://github.com/plausible/ch/pull/296
 - use gregorian seconds for naive datetime encoding in rowbinary (it's faster this way) https://github.com/plausible/ch/pull/311
 - use `DateTime.to_unix/2` + `DateTime.to_naive/1` for naive datetime decoding in RowBinary https://github.com/plausible/ch/pull/313
+- allow non-UTC timezones for DateTime64 RowBinary encoding https://github.com/plausible/ch/pull/315
 
 ## 0.7.1 (2026-01-15)
 

--- a/bench/datetime64_encode.exs
+++ b/bench/datetime64_encode.exs
@@ -1,27 +1,32 @@
 defmodule Bench do
-  @epoch_date ~D[1970-01-01]
-  @epoch_naive_datetime NaiveDateTime.new!(@epoch_date, ~T[00:00:00])
-  # NaiveDateTime.to_gregorian_seconds(@epoch_naive_datetime)
-  @epoch_seconds_since_gregorian 62_167_219_200
+  @epoch_gregorian_seconds 62_167_219_200
 
-  def naive_diff({time_unit, %NaiveDateTime{} = naive}) do
-    NaiveDateTime.diff(naive, @epoch_naive_datetime, time_unit)
+  def to_unix({time_unit, %DateTime{} = datetime}) do
+    DateTime.to_unix(datetime, time_unit)
   end
 
-  def to_gregorian_diff({time_unit, %NaiveDateTime{} = naive}) do
-    {seconds, micros} = NaiveDateTime.to_gregorian_seconds(naive)
-    (seconds - @epoch_seconds_since_gregorian) * time_unit + div(micros * time_unit, 1_000_000)
+  def to_gregorian({time_unit, %DateTime{} = datetime}) do
+    {seconds, micros} = DateTime.to_gregorian_seconds(datetime)
+    (seconds - @epoch_gregorian_seconds) * time_unit + div(micros * time_unit, 1_000_000)
   end
 end
 
+Calendar.put_time_zone_database(Tz.TimeZoneDatabase)
+
 Benchee.run(
   %{
-    "naive_diff" => &Bench.naive_diff/1,
-    "to_gregorian_diff" => &Bench.to_gregorian_diff/1
+    "to_unix" => &Bench.to_unix/1,
+    "to_gregorian" => &Bench.to_gregorian/1
   },
   inputs: %{
-    "DateTime64(3) now" => {_time_unit = 1_000, NaiveDateTime.utc_now()},
-    "DateTime64(6) now" => {_time_unit = 1_000_000, NaiveDateTime.utc_now()},
-    "DateTime64(9) now" => {_time_unit = 1_000_000_000, NaiveDateTime.utc_now()}
+    "DateTime64(3) now" => {_time_unit = 1_000, DateTime.utc_now()},
+    "DateTime64(6) now" => {_time_unit = 1_000_000, DateTime.utc_now()},
+    "DateTime64(9) now" => {_time_unit = 1_000_000_000, DateTime.utc_now()},
+    "DateTime64(3) now in Tahiti" =>
+      {_time_unit = 1_000, DateTime.shift_zone!(DateTime.utc_now(), "Pacific/Tahiti")},
+    "DateTime64(6) now in Tahiti" =>
+      {_time_unit = 1_000_000, DateTime.shift_zone!(DateTime.utc_now(), "Pacific/Tahiti")},
+    "DateTime64(9) now in Tahiti" =>
+      {_time_unit = 1_000_000_000, DateTime.shift_zone!(DateTime.utc_now(), "Pacific/Tahiti")}
   }
 )

--- a/bench/datetime_encode.exs
+++ b/bench/datetime_encode.exs
@@ -1,31 +1,25 @@
 defmodule Bench do
-  @epoch_date ~D[1970-01-01]
-  @epoch_naive_datetime NaiveDateTime.new!(@epoch_date, ~T[00:00:00])
+  @epoch_gregorian_seconds 62_167_219_200
 
-  {epoch_seconds_since_gregorian, _} = NaiveDateTime.to_gregorian_seconds(@epoch_naive_datetime)
-  @epoch_seconds_since_gregorian epoch_seconds_since_gregorian
-
-  def naive_diff(%NaiveDateTime{} = naive) do
-    NaiveDateTime.diff(naive, @epoch_naive_datetime)
+  def to_unix(%DateTime{} = datetime) do
+    DateTime.to_unix(datetime)
   end
 
-  def to_utc_to_unix(%NaiveDateTime{} = naive) do
-    naive |> DateTime.from_naive!("Etc/UTC") |> DateTime.to_unix()
-  end
-
-  def to_gregorian_diff(%NaiveDateTime{} = naive) do
-    {seconds, _} = NaiveDateTime.to_gregorian_seconds(naive)
-    seconds - @epoch_seconds_since_gregorian
+  def to_gregorian(%DateTime{} = datetime) do
+    {seconds, _} = DateTime.to_gregorian_seconds(datetime)
+    seconds - @epoch_gregorian_seconds
   end
 end
 
+Calendar.put_time_zone_database(Tz.TimeZoneDatabase)
+
 Benchee.run(
   %{
-    "naive_diff" => &Bench.naive_diff/1,
-    "to_utc_to_unix" => &Bench.to_utc_to_unix/1,
-    "to_gregorian_diff" => &Bench.to_gregorian_diff/1
+    "to_unix" => &Bench.to_unix/1,
+    "to_gregorian" => &Bench.to_gregorian/1
   },
   inputs: %{
-    "now" => NaiveDateTime.utc_now()
+    "now" => DateTime.utc_now(),
+    "now in Tahiti" => DateTime.shift_zone!(DateTime.utc_now(), "Pacific/Tahiti")
   }
 )

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -7,7 +7,6 @@ defmodule Ch.RowBinary do
   import Bitwise
 
   @epoch_date ~D[1970-01-01]
-  @epoch_utc_datetime DateTime.new!(@epoch_date, ~T[00:00:00])
   @epoch_gregorian_seconds 62_167_219_200
 
   @doc false
@@ -334,12 +333,8 @@ defmodule Ch.RowBinary do
     <<seconds - @epoch_gregorian_seconds::32-little>>
   end
 
-  def encode(:datetime, %DateTime{time_zone: "Etc/UTC"} = datetime) do
-    <<DateTime.to_unix(datetime, :second)::32-little>>
-  end
-
   def encode(:datetime, %DateTime{} = datetime) do
-    encode(:datetime, DateTime.shift_zone!(datetime, "Etc/UTC"))
+    <<DateTime.to_unix(datetime, :second)::32-little>>
   end
 
   def encode(:datetime, nil), do: <<0::32>>
@@ -350,12 +345,8 @@ defmodule Ch.RowBinary do
     <<(seconds - @epoch_gregorian_seconds) * time_unit + div(micros * time_unit, 1_000_000)::64-little-signed>>
   end
 
-  def encode({:datetime64, time_unit}, %DateTime{time_zone: "Etc/UTC"} = datetime) do
-    <<DateTime.diff(datetime, @epoch_utc_datetime, time_unit)::64-little-signed>>
-  end
-
-  def encode({:datetime64, _time_unit}, %DateTime{} = datetime) do
-    raise ArgumentError, "non-UTC timezones are not supported for encoding: #{datetime}"
+  def encode({:datetime64, time_unit}, %DateTime{} = datetime) do
+    <<DateTime.to_unix(datetime, time_unit)::64-little-signed>>
   end
 
   def encode({:datetime64, _time_unit}, nil), do: <<0::64>>

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -346,9 +346,7 @@ defmodule Ch.RowBinary do
   end
 
   def encode({:datetime64, time_unit}, %DateTime{} = datetime) do
-    {seconds, micros} = DateTime.to_gregorian_seconds(datetime)
-
-    <<(seconds - @epoch_gregorian_seconds) * time_unit + div(micros * time_unit, 1_000_000)::64-little-signed>>
+    <<DateTime.to_unix(datetime, time_unit)::64-little-signed>>
   end
 
   def encode({:datetime64, _time_unit}, nil), do: <<0::64>>

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -346,7 +346,9 @@ defmodule Ch.RowBinary do
   end
 
   def encode({:datetime64, time_unit}, %DateTime{} = datetime) do
-    <<DateTime.to_unix(datetime, time_unit)::64-little-signed>>
+    {seconds, micros} = DateTime.to_gregorian_seconds(datetime)
+
+    <<(seconds - @epoch_gregorian_seconds) * time_unit + div(micros * time_unit, 1_000_000)::64-little-signed>>
   end
 
   def encode({:datetime64, _time_unit}, nil), do: <<0::64>>

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Ch.MixProject do
       {:benchee, "~> 1.0", only: [:bench]},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :docs},
-      {:tz, "~> 0.28.1", only: [:test]},
+      {:tz, "~> 0.28.1", only: [:dev, :test, :bench]},
       {:excoveralls, "~> 0.18.5", only: :test}
     ]
   end


### PR DESCRIPTION
This PR also allows non-UTC timezones.