### PR TITLE
Disable test coverage upload to coveralls.io in scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,10 @@ jobs:
         if: ${{ matrix.lint }}
 
       - run: mix test --include slow
-        if: ${{ !matrix.coverage }}
+        if: ${{ !matrix.coverage || github.event_name == 'schedule' }}
 
       - run: mix coveralls.github --include slow
-        if: ${{ matrix.coverage }}
+        if: ${{ matrix.coverage && github.event_name != 'schedule' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Because it fails with something missing from action context: https://github.com/plausible/ch/actions/runs/24831366470/job/72680436945

```
** (BadMapError) expected a map, got:

    nil

    (elixir 1.19.5) lib/map.ex:541: Map.get(nil, "login", nil)
    (excoveralls 0.18.5) lib/excoveralls/github.ex:95: ExCoveralls.Github.git_info/0
    (excoveralls 0.18.5) lib/excoveralls/github.ex:27: ExCoveralls.Github.generate_json/2
    (excoveralls 0.18.5) lib/excoveralls/github.ex:9: ExCoveralls.Github.execute/2
    (elixir 1.19.5) lib/enum.ex:961: Enum."-each/2-lists^foreach/1-0-"/2
    (excoveralls 0.18.5) lib/excoveralls.ex:69: ExCoveralls.execute/3
    (mix 1.19.5) lib/mix/tasks/test.ex:692: Mix.Tasks.Test.do_run/3
    (mix 1.19.5) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (excoveralls 0.18.5) lib/mix/tasks.ex:54: Mix.Tasks.Coveralls.do_run/2
    (mix 1.19.5) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.19.5) lib/mix/cli.ex:129: Mix.CLI.run_task/2
    /home/runner/work/_temp/.setup-beam/elixir/bin/mix:7: (file)
    (elixir 1.19.5) lib/code.ex:1613: Code.require_file/2
```