### PR TITLE
Fix `xmerl` warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Ch.MixProject do
       docs: docs(),
       package: package(),
       source_url: @source_url,
-      dialyzer: [plt_local_path: "plts", plt_core_path: "plts"],
+      dialyzer: [plt_local_path: "plts", plt_core_path: "plts", plt_ignore_apps: [:xmerl]],
       test_coverage: [tool: ExCoveralls, ignore_modules: [Ch.Test]]
     ]
   end


### PR DESCRIPTION
It was included because `:excoveralls` depends on it. And was causing these warnings:

```console
$ mix dialyzer --format github
Finding suitable PLTs
Checking PLT...
[:asn1, :ch, :compiler, :crypto, :db_connection, :decimal, :ecto, :eex, :elixir, :excoveralls, :hpax, :inets, :jason, :kernel, :logger, :mint, :public_key, :ssl, :stdlib, :telemetry, :tools, :tz, :xmerl]
Looking up modules in dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt
Looking up modules in dialyxir_erlang-28.4.3_elixir-1.19.5.plt
Looking up modules in dialyxir_erlang-28.4.3.plt
Finding applications for dialyxir_erlang-28.4.3.plt
Finding modules for dialyxir_erlang-28.4.3.plt
Creating dialyxir_erlang-28.4.3.plt
Looking up modules in dialyxir_erlang-28.4.3.plt
Removing 3 modules from dialyxir_erlang-28.4.3.plt
Checking 19 modules in dialyxir_erlang-28.4.3.plt
Adding 201 modules to dialyxir_erlang-28.4.3.plt
done in 0m27.29s
Finding applications for dialyxir_erlang-28.4.3_elixir-1.19.5.plt
Finding modules for dialyxir_erlang-28.4.3_elixir-1.19.5.plt
Copying dialyxir_erlang-28.4.3.plt to dialyxir_erlang-28.4.3_elixir-1.19.5.plt
Looking up modules in dialyxir_erlang-28.4.3_elixir-1.19.5.plt
Checking 220 modules in dialyxir_erlang-28.4.3_elixir-1.19.5.plt
Adding 272 modules to dialyxir_erlang-28.4.3_elixir-1.19.5.plt
done in 0m20.02s
Finding applications for dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt
Finding modules for dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt
Copying dialyxir_erlang-28.4.3_elixir-1.19.5.plt to dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt
Looking up modules in dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt
Checking 492 modules in dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt
Adding 584 modules to dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt
Warning: xmerl_ucs.erl:58:1: Warning: missing specification for function is_iso10646/1
Warning: xmerl_ucs.erl:70:1: Warning: missing specification for function is_unicode/1
Warning: xmerl_ucs.erl:75:1: Warning: missing specification for function is_bmpchar/1
Warning: xmerl_ucs.erl:84:1: Warning: missing specification for function is_latin1/1
Warning: xmerl_ucs.erl:88:1: Warning: missing specification for function is_ascii/1
Warning: xmerl_ucs.erl:92:1: Warning: missing specification for function is_iso646_basic/1
Warning: xmerl_ucs.erl:108:1: Warning: missing specification for function is_visible_latin1/1
Warning: xmerl_ucs.erl:117:1: Warning: missing specification for function is_visible_ascii/1
Warning: xmerl_ucs.erl:122:1: Warning: missing specification for function to_ucs4be/1
Warning: xmerl_ucs.erl:125:1: Warning: missing specification for function from_ucs4be/1
Warning: xmerl_ucs.erl:128:1: Warning: missing specification for function from_ucs4be/2
Warning: xmerl_ucs.erl:131:1: Warning: missing specification for function to_ucs4le/1
Warning: xmerl_ucs.erl:134:1: Warning: missing specification for function from_ucs4le/1
Warning: xmerl_ucs.erl:137:1: Warning: missing specification for function from_ucs4le/2
Warning: xmerl_ucs.erl:141:1: Warning: missing specification for function to_ucs2be/1
Warning: xmerl_ucs.erl:144:1: Warning: missing specification for function from_ucs2be/1
Warning: xmerl_ucs.erl:147:1: Warning: missing specification for function from_ucs2be/2
Warning: xmerl_ucs.erl:150:1: Warning: missing specification for function to_ucs2le/1
Warning: xmerl_ucs.erl:153:1: Warning: missing specification for function from_ucs2le/1
Warning: xmerl_ucs.erl:156:1: Warning: missing specification for function from_ucs2le/2
Warning: xmerl_ucs.erl:161:1: Warning: missing specification for function to_utf16be/1
Warning: xmerl_ucs.erl:164:1: Warning: missing specification for function from_utf16be/1
Warning: xmerl_ucs.erl:167:1: Warning: missing specification for function from_utf16be/2
Warning: xmerl_ucs.erl:170:1: Warning: missing specification for function to_utf16le/1
Warning: xmerl_ucs.erl:173:1: Warning: missing specification for function from_utf16le/1
Warning: xmerl_ucs.erl:176:1: Warning: missing specification for function from_utf16le/2
Warning: xmerl_ucs.erl:181:1: Warning: missing specification for function to_utf8/1
Warning: xmerl_ucs.erl:184:1: Warning: missing specification for function from_utf8/1
Warning: xmerl_ucs.erl:193:1: Warning: missing specification for function from_latin9/1
Warning: xmerl_ucs.erl:483:1: Warning: missing specification for function to_unicode/2
Warning: xmerl_ucs.erl:523:1: Warning: missing specification for function is_incharset/2
done in 1m29.34s
No :ignore_warnings opt specified in mix.exs and default does not exist.
Starting Dialyzer
[
check_plt: false,
init_plt: ~c"plts/dialyxir_erlang-28.4.3_elixir-1.19.5_deps-test.plt",
files: [~c"/home/runner/work/ch/ch/_build/test/lib/ch/ebin/Elixir.Ch.Connection.beam",
~c"/home/runner/work/ch/ch/_build/test/lib/ch/ebin/Elixir.Ch.Error.beam",
~c"/home/runner/work/ch/ch/_build/test/lib/ch/ebin/Elixir.Ch.Query.beam",
~c"/home/runner/work/ch/ch/_build/test/lib/ch/ebin/Elixir.Ch.Result.beam",
~c"/home/runner/work/ch/ch/_build/test/lib/ch/ebin/Elixir.Ch.RowBinary.beam",
...],
...
]
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m4.34s
done (passed successfully)
```