### PR TITLE
`Ch.type/1` fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - allow non-UTC timezones for DateTime64 RowBinary encoding https://github.com/plausible/ch/pull/315
 - use gregorian days in RowBinary dates https://github.com/plausible/ch/pull/318
 
+## 0.8.0 (2026-05-03)
+
+- fix `Ch.type/1` callback
+
 ## 0.7.1 (2026-01-15)
 
 > [!WARNING]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - use `DateTime.to_unix/2` + `DateTime.to_naive/1` for naive datetime decoding in RowBinary https://github.com/plausible/ch/pull/313
 - allow non-UTC timezones for DateTime64 RowBinary encoding https://github.com/plausible/ch/pull/315
 - use gregorian days in RowBinary dates https://github.com/plausible/ch/pull/318
-- fix `Ch.type/1` callback
+- fix `Ch.type/1` callback https://github.com/plausible/ch/pull/331
 
 ## 0.7.1 (2026-01-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@
 - use `DateTime.to_unix/2` + `DateTime.to_naive/1` for naive datetime decoding in RowBinary https://github.com/plausible/ch/pull/313
 - allow non-UTC timezones for DateTime64 RowBinary encoding https://github.com/plausible/ch/pull/315
 - use gregorian days in RowBinary dates https://github.com/plausible/ch/pull/318
-
-## 0.8.0 (2026-05-03)
-
 - fix `Ch.type/1` callback
 
 ## 0.7.1 (2026-01-15)

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -125,7 +125,52 @@ defmodule Ch do
     @behaviour Ecto.ParameterizedType
 
     @impl Ecto.ParameterizedType
-    def type(params), do: {:parameterized, {Ch, params}}
+    def type(:string), do: :string
+    def type(:boolean), do: :boolean
+    def type(:uuid), do: Ecto.UUID
+    def type(:date), do: :date
+    def type(:date32), do: :date
+    def type(:time), do: :time
+    def type({:time64, _p}), do: :time
+    def type(:datetime), do: :naive_datetime
+    def type({:datetime, "UTC"}), do: :utc_datetime
+    def type({:datetime64, _p}), do: :naive_datetime_usec
+    def type({:datetime64, _p, "UTC"}), do: :utc_datetime_usec
+    def type({:fixed_string, _s}), do: :string
+    def type(:json), do: :map
+    def type(:dynamic), do: :any
+
+    for size <- [8, 16, 32, 64, 128, 256] do
+      def type(unquote(:"i#{size}")), do: :integer
+      def type(unquote(:"u#{size}")), do: :integer
+    end
+
+    for size <- [32, 64] do
+      def type(unquote(:"f#{size}")), do: :float
+    end
+
+    def type({:decimal, _p, _s}), do: :decimal
+
+    for size <- [32, 64, 128, 256] do
+      def type({unquote(:"decimal#{size}"), _s}) do
+        :decimal
+      end
+    end
+
+    def type({:array, type}), do: {:array, type(type)}
+    def type({:nullable, type}), do: type(type)
+    def type({:low_cardinality, type}), do: type(type)
+    def type({:simple_aggregate_function, _name, type}), do: type(type)
+    def type(:ring), do: {:array, type(:point)}
+    def type(:polygon), do: {:array, type(:ring)}
+    def type(:multipolygon), do: {:array, type(:polygon)}
+    def type({enum, _mappings}) when enum in [:enum8, :enum16], do: :any
+    def type(:ipv4), do: :any
+    def type(:ipv6), do: :any
+    def type(:point), do: :any
+    def type({:tuple, _types}), do: :any
+    def type({:map, _key_type, _value_type}), do: :map
+    def type({:variant, _types}), do: :any
 
     @impl Ecto.ParameterizedType
     def init(opts) do

--- a/lib/ch.ex
+++ b/lib/ch.ex
@@ -133,9 +133,9 @@ defmodule Ch do
     def type(:time), do: :time
     def type({:time64, _p}), do: :time
     def type(:datetime), do: :naive_datetime
-    def type({:datetime, "UTC"}), do: :utc_datetime
+    def type({:datetime, _tz}), do: :utc_datetime
     def type({:datetime64, _p}), do: :naive_datetime_usec
-    def type({:datetime64, _p, "UTC"}), do: :utc_datetime_usec
+    def type({:datetime64, _p, _tz}), do: :utc_datetime_usec
     def type({:fixed_string, _s}), do: :string
     def type(:json), do: :map
     def type(:dynamic), do: :any
@@ -196,9 +196,9 @@ defmodule Ch do
     def cast(value, :time = type), do: Ecto.Type.cast(type, value)
     def cast(value, {:time64, _p}), do: Ecto.Type.cast(:time, value)
     def cast(value, :datetime), do: Ecto.Type.cast(:naive_datetime, value)
-    def cast(value, {:datetime, "UTC"}), do: Ecto.Type.cast(:utc_datetime, value)
+    def cast(value, {:datetime, _tz}), do: Ecto.Type.cast(:utc_datetime, value)
     def cast(value, {:datetime64, _p}), do: Ecto.Type.cast(:naive_datetime_usec, value)
-    def cast(value, {:datetime64, _p, "UTC"}), do: Ecto.Type.cast(:utc_datetime_usec, value)
+    def cast(value, {:datetime64, _p, _tz}), do: Ecto.Type.cast(:utc_datetime_usec, value)
     def cast(value, {:fixed_string, _s}), do: Ecto.Type.cast(:string, value)
     def cast(value, :json), do: Ecto.Type.cast(:map, value)
     def cast(value, :dynamic), do: {:ok, value}

--- a/test/ch/ecto_type_test.exs
+++ b/test/ch/ecto_type_test.exs
@@ -19,7 +19,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :string}} =
              type = Ecto.ParameterizedType.init(Ch, type: "String")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :string
     assert Ecto.Type.format(type) == "#Ch<String>"
 
     assert {:ok, "something"} = Ecto.Type.cast(type, "something")
@@ -37,7 +37,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:nullable, :string}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Nullable(String)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :string
     assert Ecto.Type.format(type) == "#Ch<Nullable(String)>"
 
     assert {:ok, "something"} = Ecto.Type.cast(type, "something")
@@ -55,7 +55,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:low_cardinality, :string}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "LowCardinality(String)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :string
     assert Ecto.Type.format(type) == "#Ch<LowCardinality(String)>"
 
     assert {:ok, "something"} = Ecto.Type.cast(type, "something")
@@ -73,7 +73,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:array, :string}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Array(String)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == {:array, :string}
     assert Ecto.Type.format(type) == "#Ch<Array(String)>"
 
     assert {:ok, ["something"]} = Ecto.Type.cast(type, ["something"])
@@ -93,7 +93,7 @@ defmodule Ch.EctoTypeTest do
     assert {:array, {:parameterized, {Ch, :string}}} =
              type = {:array, Ecto.ParameterizedType.init(Ch, type: "String")}
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == {:array, :string}
     assert Ecto.Type.format(type) == "{:array, #Ch<String>}"
 
     assert {:ok, ["something"]} = Ecto.Type.cast(type, ["something"])
@@ -113,7 +113,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:tuple, [:string, :i64]}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Tuple(String, Int64)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :any
     assert Ecto.Type.format(type) == "#Ch<Tuple(String, Int64)>"
 
     assert {:ok, {"something", 42}} = Ecto.Type.cast(type, {"something", 42})
@@ -131,7 +131,7 @@ defmodule Ch.EctoTypeTest do
              type =
              Ecto.ParameterizedType.init(Ch, type: "Variant(UInt64, String, Array(UInt64))")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :any
     assert Ecto.Type.format(type) == "#Ch<Variant(Array(UInt64), String, UInt64)>"
 
     assert {:ok, [1]} = Ecto.Type.cast(type, [1])
@@ -150,7 +150,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :dynamic}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Dynamic")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :any
     assert Ecto.Type.format(type) == "#Ch<Dynamic>"
 
     assert {:ok, [1]} = Ecto.Type.cast(type, [1])
@@ -168,7 +168,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :dynamic}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Dynamic(max_types=10)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :any
     assert Ecto.Type.format(type) == "#Ch<Dynamic>"
 
     assert {:ok, [1]} = Ecto.Type.cast(type, [1])
@@ -185,7 +185,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :json}} =
              type = Ecto.ParameterizedType.init(Ch, type: "JSON")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :map
     assert Ecto.Type.format(type) == "#Ch<JSON>"
 
     assert {:ok, %{}} = Ecto.Type.cast(type, %{})
@@ -209,7 +209,7 @@ defmodule Ch.EctoTypeTest do
         assert {:parameterized, {Ch, unquote(decoded)}} =
                  type = Ecto.ParameterizedType.init(Ch, type: unquote(encoded))
 
-        assert Ecto.Type.type(type) == type
+        assert Ecto.Type.type(type) == :integer
         assert Ecto.Type.format(type) == "#Ch<#{unquote(encoded)}>"
 
         assert {:ok, 1} = Ecto.Type.cast(type, 1)
@@ -227,7 +227,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:map, :string, :u64}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Map(String, UInt64)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :map
     assert Ecto.Type.format(type) == "#Ch<Map(String, UInt64)>"
 
     assert {:ok, %{"answer" => 42}} = Ecto.Type.cast(type, %{"answer" => 42})
@@ -242,7 +242,7 @@ defmodule Ch.EctoTypeTest do
       assert {:parameterized, {Ch, unquote(:"f#{size}")}} =
                type = Ecto.ParameterizedType.init(Ch, type: unquote("Float#{size}"))
 
-      assert Ecto.Type.type(type) == type
+      assert Ecto.Type.type(type) == :float
       assert Ecto.Type.format(type) == "#Ch<Float#{unquote(size)}>"
 
       assert {:ok, 1.0} = Ecto.Type.cast(type, 1.0)
@@ -260,7 +260,7 @@ defmodule Ch.EctoTypeTest do
   test "Date" do
     assert {:parameterized, {Ch, :date}} = type = Ecto.ParameterizedType.init(Ch, type: "Date")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :date
     assert Ecto.Type.format(type) == "#Ch<Date>"
 
     assert {:ok, ~D[2001-01-01]} = Ecto.Type.cast(type, ~D[2001-01-01])
@@ -277,7 +277,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :date32}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Date32")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :date
     assert Ecto.Type.format(type) == "#Ch<Date32>"
 
     assert {:ok, ~D[2001-01-01]} = Ecto.Type.cast(type, ~D[2001-01-01])
@@ -293,7 +293,7 @@ defmodule Ch.EctoTypeTest do
   test "Time" do
     assert {:parameterized, {Ch, :time}} = type = Ecto.ParameterizedType.init(Ch, type: "Time")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :time
     assert Ecto.Type.format(type) == "#Ch<Time>"
 
     assert {:ok, ~T[12:34:56]} = Ecto.Type.cast(type, ~T[12:34:56])
@@ -310,7 +310,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:time64, 6}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Time64(6)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :time
     assert Ecto.Type.format(type) == "#Ch<Time64(6)>"
 
     assert {:ok, ~T[12:34:56]} = Ecto.Type.cast(type, ~T[12:34:56])
@@ -326,7 +326,7 @@ defmodule Ch.EctoTypeTest do
   test "Bool" do
     assert {:parameterized, {Ch, :boolean}} = type = Ecto.ParameterizedType.init(Ch, type: "Bool")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :boolean
     assert Ecto.Type.format(type) == "#Ch<Bool>"
 
     assert {:ok, true} = Ecto.Type.cast(type, true)
@@ -343,7 +343,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :datetime}} =
              type = Ecto.ParameterizedType.init(Ch, type: "DateTime")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :naive_datetime
     assert Ecto.Type.format(type) == "#Ch<DateTime>"
 
     assert {:ok, ~N[2001-01-01 12:00:00]} = Ecto.Type.cast(type, ~N[2001-01-01 12:00:00])
@@ -360,7 +360,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:datetime, "UTC"}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "DateTime('UTC')")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :utc_datetime
     assert Ecto.Type.format(type) == "#Ch<DateTime('UTC')>"
 
     assert {:ok, ~U[2001-01-01 12:00:00Z]} = Ecto.Type.cast(type, ~U[2001-01-01 12:00:00Z])
@@ -378,7 +378,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:datetime64, 3}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "DateTime64(3)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :naive_datetime_usec
     assert Ecto.Type.format(type) == "#Ch<DateTime64(3)>"
 
     assert {:ok, ~N[2001-01-01 12:00:00.123456]} =
@@ -403,7 +403,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:datetime64, 3, "UTC"}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "DateTime64(3, 'UTC')")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :utc_datetime_usec
     assert Ecto.Type.format(type) == "#Ch<DateTime64(3, 'UTC')>"
 
     assert {:ok, ~U[2001-01-01 12:00:00.123456Z]} =
@@ -427,7 +427,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:simple_aggregate_function, "any", :string}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "SimpleAggregateFunction(any, String)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :string
     assert Ecto.Type.format(type) == "#Ch<SimpleAggregateFunction(any, String)>"
 
     assert {:ok, "something"} = Ecto.Type.cast(type, "something")
@@ -449,7 +449,7 @@ defmodule Ch.EctoTypeTest do
                type: "SimpleAggregateFunction(groupArrayArray, Array(DateTime('UTC')))"
              )
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == {:array, :utc_datetime}
 
     assert Ecto.Type.format(type) ==
              "#Ch<SimpleAggregateFunction(groupArrayArray, Array(DateTime('UTC')))>"
@@ -473,7 +473,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:fixed_string, 3}}} =
              type = Ecto.ParameterizedType.init(Ch, type: "FixedString(3)")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :string
     assert Ecto.Type.format(type) == "#Ch<FixedString(3)>"
 
     assert {:ok, "som"} = Ecto.Type.cast(type, "som")
@@ -497,7 +497,7 @@ defmodule Ch.EctoTypeTest do
       assert {:parameterized, {Ch, {unquote(decoded), [{"hello", 1}, {"world", 2}]}}} =
                type = Ecto.ParameterizedType.init(Ch, type: unquote(full_encoded))
 
-      assert Ecto.Type.type(type) == type
+      assert Ecto.Type.type(type) == :any
       assert Ecto.Type.format(type) == "#Ch<#{unquote(full_encoded)}>"
 
       assert {:ok, "hello"} = Ecto.Type.cast(type, "hello")
@@ -525,7 +525,7 @@ defmodule Ch.EctoTypeTest do
   test "UUID" do
     assert {:parameterized, {Ch, :uuid}} = type = Ecto.ParameterizedType.init(Ch, type: "UUID")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == Ecto.UUID
     assert Ecto.Type.format(type) == "#Ch<UUID>"
 
     uuid = Ecto.UUID.generate()
@@ -542,7 +542,7 @@ defmodule Ch.EctoTypeTest do
   test "IPv4" do
     assert {:parameterized, {Ch, :ipv4}} = type = Ecto.ParameterizedType.init(Ch, type: "IPv4")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :any
     assert Ecto.Type.format(type) == "#Ch<IPv4>"
 
     assert {:ok, {127, 0, 0, 1}} = Ecto.Type.cast(type, "127.0.0.1")
@@ -561,7 +561,7 @@ defmodule Ch.EctoTypeTest do
   test "IPv6" do
     assert {:parameterized, {Ch, :ipv6}} = type = Ecto.ParameterizedType.init(Ch, type: "IPv6")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :any
     assert Ecto.Type.format(type) == "#Ch<IPv6>"
 
     assert {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} = Ecto.Type.cast(type, "::1")
@@ -583,7 +583,7 @@ defmodule Ch.EctoTypeTest do
   test "Point" do
     assert {:parameterized, {Ch, :point}} = type = Ecto.ParameterizedType.init(Ch, type: "Point")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :any
     assert Ecto.Type.format(type) == "#Ch<Point>"
 
     assert {:ok, {10, 10}} == Ecto.Type.cast(type, {10, 10})
@@ -601,7 +601,7 @@ defmodule Ch.EctoTypeTest do
   test "Ring" do
     assert {:parameterized, {Ch, :ring}} = type = Ecto.ParameterizedType.init(Ch, type: "Ring")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == {:array, :any}
     assert Ecto.Type.format(type) == "#Ch<Ring>"
 
     ring = [{0, 0}, {10, 0}, {10, 10}, {0, 10}]
@@ -614,7 +614,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :polygon}} =
              type = Ecto.ParameterizedType.init(Ch, type: "Polygon")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == {:array, {:array, :any}}
     assert Ecto.Type.format(type) == "#Ch<Polygon>"
 
     polygon = [
@@ -631,7 +631,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, :multipolygon}} =
              type = Ecto.ParameterizedType.init(Ch, type: "MultiPolygon")
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == {:array, {:array, {:array, :any}}}
     assert Ecto.Type.format(type) == "#Ch<MultiPolygon>"
 
     multipolygon = [
@@ -648,7 +648,7 @@ defmodule Ch.EctoTypeTest do
     assert {:parameterized, {Ch, {:decimal, 18, 4}}} =
              type = Ecto.ParameterizedType.init(Ch, type: unquote("Decimal(18, 4)"))
 
-    assert Ecto.Type.type(type) == type
+    assert Ecto.Type.type(type) == :decimal
     assert Ecto.Type.format(type) == "#Ch<Decimal(18, 4)>"
 
     assert {:ok, %Decimal{}} = Ecto.Type.cast(type, 1.0)
@@ -669,7 +669,7 @@ defmodule Ch.EctoTypeTest do
           256 -> 76
         end
 
-      assert Ecto.Type.type(type) == type
+      assert Ecto.Type.type(type) == :decimal
       assert Ecto.Type.format(type) == "#Ch<Decimal(#{precision}, 4)>"
 
       assert {:ok, %Decimal{}} = Ecto.Type.cast(type, 1.0)

--- a/test/ch/ecto_type_test.exs
+++ b/test/ch/ecto_type_test.exs
@@ -373,6 +373,23 @@ defmodule Ch.EctoTypeTest do
     assert {:ok, ~U[2001-01-01 12:00:00Z]} = Ecto.Type.load(type, ~U[2001-01-01 12:00:00Z])
   end
 
+  test "DateTime('Europe/Vienna')" do
+    assert {:parameterized, {Ch, {:datetime, "Europe/Vienna"}}} =
+             type = Ecto.ParameterizedType.init(Ch, type: "DateTime('Europe/Vienna')")
+
+    assert Ecto.Type.type(type) == :utc_datetime
+    assert Ecto.Type.format(type) == "#Ch<DateTime('Europe/Vienna')>"
+
+    assert {:ok, ~U[2001-01-01 12:00:00Z]} = Ecto.Type.cast(type, ~U[2001-01-01 12:00:00Z])
+    assert {:ok, ~U[2001-01-01 12:00:00Z]} = Ecto.Type.cast(type, "2001-01-01 12:00:00Z")
+    assert {:ok, nil} = Ecto.Type.cast(type, nil)
+
+    assert :error = Ecto.Type.cast(type, "asdf")
+
+    assert {:ok, ~U[2001-01-01 12:00:00Z]} = Ecto.Type.dump(type, ~U[2001-01-01 12:00:00Z])
+    assert {:ok, ~U[2001-01-01 12:00:00Z]} = Ecto.Type.load(type, ~U[2001-01-01 12:00:00Z])
+  end
+
   # TODO truncate?
   test "DateTime64(3)" do
     assert {:parameterized, {Ch, {:datetime64, 3}}} =
@@ -405,6 +422,30 @@ defmodule Ch.EctoTypeTest do
 
     assert Ecto.Type.type(type) == :utc_datetime_usec
     assert Ecto.Type.format(type) == "#Ch<DateTime64(3, 'UTC')>"
+
+    assert {:ok, ~U[2001-01-01 12:00:00.123456Z]} =
+             Ecto.Type.cast(type, ~U[2001-01-01 12:00:00.123456Z])
+
+    assert {:ok, ~U[2001-01-01 12:00:00.123456Z]} =
+             Ecto.Type.cast(type, "2001-01-01 12:00:00.123456Z")
+
+    assert {:ok, nil} = Ecto.Type.cast(type, nil)
+
+    assert :error = Ecto.Type.cast(type, "asdf")
+
+    assert {:ok, ~U[2001-01-01 12:00:00.123456Z]} =
+             Ecto.Type.dump(type, ~U[2001-01-01 12:00:00.123456Z])
+
+    assert {:ok, ~U[2001-01-01 12:00:00.123456Z]} =
+             Ecto.Type.load(type, ~U[2001-01-01 12:00:00.123456Z])
+  end
+
+  test "DateTime64(3, 'Asia/Taipei')" do
+    assert {:parameterized, {Ch, {:datetime64, 3, "Asia/Taipei"}}} =
+             type = Ecto.ParameterizedType.init(Ch, type: "DateTime64(3, 'Asia/Taipei')")
+
+    assert Ecto.Type.type(type) == :utc_datetime_usec
+    assert Ecto.Type.format(type) == "#Ch<DateTime64(3, 'Asia/Taipei')>"
 
     assert {:ok, ~U[2001-01-01 12:00:00.123456Z]} =
              Ecto.Type.cast(type, ~U[2001-01-01 12:00:00.123456Z])


### PR DESCRIPTION
`Ch.type/1` was never supposed to return `{:parametirized, ...}`

Context: https://github.com/elixir-ecto/ecto/issues/4723