### PR TITLE
[codex] Add RowBinary integer property tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Breaking:** `Ch.RowBinary` no longer has a separate `:binary` type. Use `:string` for ClickHouse `String`; it now preserves raw bytes and no longer replaces invalid UTF-8 with the replacement character.
 - Remove the `Jason` dependency. JSON encoding/decoding now uses Elixir's built-in `JSON` module.
 - Add explicit request and response compression support through HTTP headers. `zstd` and `gzip` response bodies are decompressed automatically for decoded `RowBinaryWithNamesAndTypes` and error responses; raw successful responses are kept as received in `Ch.Result.data`.
+- Fix RowBinary integer encoders to reject out-of-range `Int16`/`UInt16` and wider values instead of silently wrapping, with added property coverage through 256-bit integer types.
 
 ## 0.8.3 (2026-05-12)
 

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -227,16 +227,31 @@ defmodule Ch.RowBinary do
   end
 
   for size <- [16, 32, 64, 128, 256] do
-    def encode(unquote(:"u#{size}"), u) when is_integer(u) do
+    unsigned_max = (1 <<< size) - 1
+    signed_min = -(1 <<< (size - 1))
+    signed_max = (1 <<< (size - 1)) - 1
+    uint = :"u#{size}"
+    int = :"i#{size}"
+
+    def encode(unquote(uint), u) when is_integer(u) and u >= 0 and u <= unquote(unsigned_max) do
       <<u::unquote(size)-little>>
     end
 
-    def encode(unquote(:"i#{size}"), i) when is_integer(i) do
+    def encode(unquote(int), i)
+        when is_integer(i) and i >= unquote(signed_min) and i <= unquote(signed_max) do
       <<i::unquote(size)-little-signed>>
     end
 
-    def encode(unquote(:"u#{size}"), nil), do: <<0::unquote(size)>>
-    def encode(unquote(:"i#{size}"), nil), do: <<0::unquote(size)>>
+    def encode(unquote(uint), nil), do: <<0::unquote(size)>>
+    def encode(unquote(int), nil), do: <<0::unquote(size)>>
+
+    def encode(unquote(uint), term) do
+      raise ArgumentError, "invalid UInt#{unquote(size)}: #{inspect(term)}"
+    end
+
+    def encode(unquote(int), term) do
+      raise ArgumentError, "invalid Int#{unquote(size)}: #{inspect(term)}"
+    end
   end
 
   for size <- [32, 64] do

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -270,7 +270,7 @@ defmodule Ch.ConnectionTest do
       Ch.stop(cleanup)
     end)
 
-    rows = [[1, nil], [-1, nil]]
+    rows = [[1, nil], [4_294_967_295, nil]]
     rowbinary = RowBinary.encode_rows(rows, ["UInt32", "Nullable(String)"])
 
     Ch.query!(pool, [

--- a/test/ch/row_binary_integer_test.exs
+++ b/test/ch/row_binary_integer_test.exs
@@ -1,0 +1,129 @@
+defmodule Ch.RowBinaryIntegerTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  import Bitwise
+
+  @uint_types [
+    u8: 8,
+    u16: 16,
+    u32: 32,
+    u64: 64,
+    u128: 128,
+    u256: 256
+  ]
+
+  @int_types [
+    i8: 8,
+    i16: 16,
+    i32: 32,
+    i64: 64,
+    i128: 128,
+    i256: 256
+  ]
+
+  describe "unsigned integers" do
+    property "encode and decode all bit patterns as little-endian values" do
+      check all {type, bits, bytes, value} <- uint_value() do
+        assert encoded_binary(type, value) == bytes
+        assert RowBinary.decode_rows(bytes, [type]) == [[value]]
+        assert bit_size(bytes) == bits
+      end
+    end
+
+    test "reject out-of-range and non-integer values" do
+      for {type, bits} <- @uint_types do
+        max = (1 <<< bits) - 1
+        type_name = "UInt#{bits}"
+
+        assert_raise ArgumentError, "invalid #{type_name}: -1", fn ->
+          RowBinary.encode(type, -1)
+        end
+
+        assert_raise ArgumentError, "invalid #{type_name}: #{max + 1}", fn ->
+          RowBinary.encode(type, max + 1)
+        end
+
+        assert_raise ArgumentError, "invalid #{type_name}: \"1\"", fn ->
+          RowBinary.encode(type, "1")
+        end
+      end
+    end
+  end
+
+  describe "signed integers" do
+    property "encode and decode all bit patterns as little-endian values" do
+      check all {type, bits, bytes, value} <- int_value() do
+        assert encoded_binary(type, value) == bytes
+        assert RowBinary.decode_rows(bytes, [type]) == [[value]]
+        assert bit_size(bytes) == bits
+      end
+    end
+
+    test "reject out-of-range and non-integer values" do
+      for {type, bits} <- @int_types do
+        min = -(1 <<< (bits - 1))
+        max = (1 <<< (bits - 1)) - 1
+        type_name = "Int#{bits}"
+
+        assert_raise ArgumentError, "invalid #{type_name}: #{min - 1}", fn ->
+          RowBinary.encode(type, min - 1)
+        end
+
+        assert_raise ArgumentError, "invalid #{type_name}: #{max + 1}", fn ->
+          RowBinary.encode(type, max + 1)
+        end
+
+        assert_raise ArgumentError, "invalid #{type_name}: \"1\"", fn ->
+          RowBinary.encode(type, "1")
+        end
+      end
+    end
+  end
+
+  test "boundary values round-trip" do
+    for {type, bits} <- @uint_types do
+      max = (1 <<< bits) - 1
+
+      assert RowBinary.decode_rows(encoded_binary(type, 0), [type]) == [[0]]
+
+      assert RowBinary.decode_rows(encoded_binary(type, max), [type]) == [[max]]
+    end
+
+    for {type, bits} <- @int_types do
+      min = -(1 <<< (bits - 1))
+      max = (1 <<< (bits - 1)) - 1
+
+      assert RowBinary.decode_rows(encoded_binary(type, min), [type]) == [[min]]
+
+      assert RowBinary.decode_rows(encoded_binary(type, max), [type]) == [[max]]
+    end
+  end
+
+  defp uint_value do
+    gen all {type, bits} <- member_of(@uint_types),
+            bytes <- binary(length: div(bits, 8)) do
+      {type, bits, bytes, :binary.decode_unsigned(bytes, :little)}
+    end
+  end
+
+  defp int_value do
+    gen all {type, bits} <- member_of(@int_types),
+            bytes <- binary(length: div(bits, 8)) do
+      unsigned = :binary.decode_unsigned(bytes, :little)
+      signed_limit = 1 <<< (bits - 1)
+      value = if unsigned >= signed_limit, do: unsigned - (1 <<< bits), else: unsigned
+
+      {type, bits, bytes, value}
+    end
+  end
+
+  defp encoded_binary(type, value) do
+    case RowBinary.encode(type, value) do
+      byte when is_integer(byte) -> <<byte>>
+      iodata -> IO.iodata_to_binary(iodata)
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- Added focused RowBinary integer property tests for signed and unsigned integer widths through 256 bits.
- Added boundary and invalid-value coverage for integer encoders.
- Tightened RowBinary `Int16`/`UInt16` and wider integer encoders to reject out-of-range values instead of silently wrapping through bitstring construction.
- Updated the changelog and adjusted an existing `UInt32` test to use the explicit maximum value.

## Why

Elixir bitstring integer construction wraps values that do not fit the target width. That meant wider RowBinary integer encoders could accept invalid values such as `-1` for `UInt32` or a value above the signed maximum, producing wrapped bytes instead of raising.

## Validation

- `mix test test/ch/row_binary_test.exs test/ch/row_binary_integer_test.exs`
- `mix test`
