### PR TITLE
[codex] fix Time64 RowBinary precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Breaking:** `Ch.RowBinary` no longer has a separate `:binary` type. Use `:string` for ClickHouse `String`; it now preserves raw bytes and no longer replaces invalid UTF-8 with the replacement character.
 - Remove the `Jason` dependency. JSON encoding/decoding now uses Elixir's built-in `JSON` module.
 - Add explicit request and response compression support through HTTP headers. `zstd` and `gzip` response bodies are decompressed automatically for decoded `RowBinaryWithNamesAndTypes` and error responses; raw successful responses are kept as received in `Ch.Result.data`.
+- Fix `Time64` RowBinary encoding for precisions below microseconds.
 
 ## 0.8.3 (2026-05-12)
 

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -366,7 +366,7 @@ defmodule Ch.RowBinary do
 
     micros_as_ticks =
       cond do
-        time_unit < 1_000_000 -> div(micros, time_unit)
+        time_unit < 1_000_000 -> div(micros, div(1_000_000, time_unit))
         time_unit == 1_000_000 -> micros
         true -> micros * div(time_unit, 1_000_000)
       end

--- a/test/ch/time_integration_test.exs
+++ b/test/ch/time_integration_test.exs
@@ -1,0 +1,88 @@
+defmodule Ch.TimeIntegrationTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  @moduletag :time
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "Time params round-trip through ClickHouse at second precision", %{pool: pool} do
+    check all time <- time_second_gen() do
+      assert Ch.query!(pool, "SELECT {value:Time}", %{"value" => time}).rows ==
+               [[time]]
+    end
+  end
+
+  property "Time64 params round-trip through ClickHouse at their declared precision", %{
+    pool: pool
+  } do
+    check all precision <- integer(0..6),
+              time <- time_gen() do
+      assert Ch.query!(pool, "SELECT {value:Time64(#{precision})}", %{"value" => time}).rows ==
+               [[truncate_time(time, precision)]]
+    end
+  end
+
+  test "Time and Time64 can be inserted with RowBinary and selected", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE time_integration_rowbinary(
+      t Time,
+      t64_0 Time64(0),
+      t64_3 Time64(3),
+      t64_6 Time64(6)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE time_integration_rowbinary") end)
+
+    rows = [
+      [~T[00:00:00.987654], ~T[00:00:00.987654], ~T[00:00:00.987654], ~T[00:00:00.987654]],
+      [~T[12:34:56.987654], ~T[12:34:56.987654], ~T[12:34:56.987654], ~T[12:34:56.987654]],
+      [~T[23:59:59.999999], ~T[23:59:59.999999], ~T[23:59:59.999999], ~T[23:59:59.999999]]
+    ]
+
+    types = ["Time", "Time64(0)", "Time64(3)", "Time64(6)"]
+    rowbinary = Ch.RowBinary.encode_rows(rows, types)
+
+    Ch.query!(pool, ["INSERT INTO time_integration_rowbinary FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM time_integration_rowbinary ORDER BY t").rows == [
+             [~T[00:00:00], ~T[00:00:00], ~T[00:00:00.987], ~T[00:00:00.987654]],
+             [~T[12:34:56], ~T[12:34:56], ~T[12:34:56.987], ~T[12:34:56.987654]],
+             [~T[23:59:59], ~T[23:59:59], ~T[23:59:59.999], ~T[23:59:59.999999]]
+           ]
+  end
+
+  defp time_gen do
+    gen all hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59),
+            microsecond <- integer(0..999_999) do
+      Time.new!(hour, minute, second, {microsecond, 6})
+    end
+  end
+
+  defp time_second_gen do
+    gen all hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59) do
+      Time.new!(hour, minute, second)
+    end
+  end
+
+  defp truncate_time(time, precision) do
+    {microsecond, _} = time.microsecond
+
+    microsecond =
+      if precision == 6 do
+        microsecond
+      else
+        scale = Integer.pow(10, 6 - precision)
+        div(microsecond, scale) * scale
+      end
+
+    %{time | microsecond: {microsecond, precision}}
+  end
+end

--- a/test/ch/time_row_binary_test.exs
+++ b/test/ch/time_row_binary_test.exs
@@ -1,0 +1,87 @@
+defmodule Ch.TimeRowBinaryTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  property "Time values round-trip through RowBinary at second precision" do
+    check all time <- time_gen() do
+      expected = truncate_time(time, 0)
+
+      assert [[^expected]] =
+               time
+               |> encode_one("Time")
+               |> RowBinary.decode_rows(["Time"])
+    end
+  end
+
+  property "Time64 values round-trip through RowBinary at their declared precision" do
+    check all precision <- integer(0..9),
+              time <- time_gen() do
+      type = "Time64(#{precision})"
+      expected = truncate_time(time, precision)
+
+      assert [[^expected]] =
+               time
+               |> encode_one(type)
+               |> RowBinary.decode_rows([type])
+    end
+  end
+
+  test "Time64 encoder truncates fractional ticks for sub-microsecond precision" do
+    time = ~T[12:34:56.987654]
+
+    assert RowBinary.encode({:time64, 1}, time) ==
+             <<12 * 60 * 60 + 34 * 60 + 56::64-little-signed>>
+
+    assert RowBinary.encode({:time64, 10}, time) ==
+             <<452_960 + 9::64-little-signed>>
+
+    assert RowBinary.encode({:time64, 100}, time) ==
+             <<4_529_600 + 98::64-little-signed>>
+
+    assert RowBinary.encode({:time64, 1_000}, time) ==
+             <<45_296_000 + 987::64-little-signed>>
+  end
+
+  test "Time64 decoder rejects ClickHouse values outside Elixir's Time range" do
+    assert_raise ArgumentError, ~r/out of Elixir's Time range/, fn ->
+      RowBinary.decode_rows(<<-1::64-little-signed>>, ["Time64(6)"])
+    end
+
+    assert_raise ArgumentError, ~r/out of Elixir's Time range/, fn ->
+      RowBinary.decode_rows(<<86_400_000_000::64-little-signed>>, ["Time64(6)"])
+    end
+  end
+
+  defp encode_one(value, type) do
+    [[value]]
+    |> RowBinary.encode_rows([type])
+    |> IO.iodata_to_binary()
+  end
+
+  defp time_gen do
+    gen all hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59),
+            microsecond <- integer(0..999_999) do
+      Time.new!(hour, minute, second, {microsecond, 6})
+    end
+  end
+
+  defp truncate_time(time, precision) do
+    {microsecond, _} = time.microsecond
+
+    precision = min(precision, 6)
+
+    microsecond =
+      if precision == 6 do
+        microsecond
+      else
+        scale = Integer.pow(10, 6 - precision)
+        div(microsecond, scale) * scale
+      end
+
+    %{time | microsecond: {microsecond, precision}}
+  end
+end


### PR DESCRIPTION
## Summary

Fix `Time64` RowBinary encoding for precisions below microseconds and add dedicated time/time64 coverage in separate test files.

## Root cause

For `Time64(0..5)`, the encoder converted microseconds to fractional ticks by dividing by the time unit itself. For precisions below microseconds, the correct divisor is the number of microseconds per tick, `1_000_000 / time_unit`.

## Impact

`Time64(0)`, `Time64(1)`, `Time64(2)`, and other sub-microsecond precisions now encode fractional time values correctly for RowBinary inserts. The added tests also cover ClickHouse query params and RowBinary insert/select behavior for `Time` and `Time64`.

## Validation

- `mix test test/ch/time_row_binary_test.exs test/ch/time_integration_test.exs`
- `mix test`
