### PR TITLE
[codex] Fix RowBinary benchmark workflow env

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ jobs:
             output_path: bench/output/decode-github-action-benchmark.json
 
     env:
-      MIX_ENV: bench
+      MIX_ENV: dev
       BENCHMARK_OUTPUT_PATH: ${{ matrix.output_path }}
 
     steps:


### PR DESCRIPTION
## Summary

Switch the RowBinary benchmark GitHub Actions job from `MIX_ENV=bench` to `MIX_ENV=dev`.

## Why

The benchmark scripts depend on modules under `dev/support`, including `Ch.Bench.RowBinaryBenchmarkData` and `GitHubActionBenchmarkFormatter`. The project already compiles those support modules and includes Benchee in the `dev` environment. Running the workflow with `MIX_ENV=bench` skipped that setup and caused the encode/decode benchmark jobs to fail before running.

## Validation

- `MIX_ENV=dev mix deps.get --only dev`
- `MIX_ENV=dev mix compile --warnings-as-errors`
- `MIX_ENV=dev mix run -e 'alias Ch.Bench.RowBinaryBenchmarkData; alias Ch.RowBinary; types = RowBinaryBenchmarkData.types(); rows = RowBinaryBenchmarkData.rows(10); encoded = RowBinary.encode_rows(rows, types) |> IO.iodata_to_binary(); true = RowBinary.decode_rows(encoded, types) == rows; true = Code.ensure_loaded?(GitHubActionBenchmarkFormatter); IO.puts("dev benchmark support OK")'`
