### PR TITLE
[codex] add missed line coverage tests

### DIFF
--- a/lib/ch/http.ex
+++ b/lib/ch/http.ex
@@ -15,6 +15,22 @@ defmodule Ch.HTTP do
 
   @doc """
   Converts a relative timeout (milliseconds) to a `t:deadline/0`.
+
+  ### Examples
+
+      iex> {:deadline, deadline} = Ch.HTTP.to_deadline(1_000)
+      iex> is_integer(deadline)
+      true
+
+      iex> (Ch.HTTP.to_deadline(1_000) |> Ch.HTTP.to_timeout()) in 0..1_000
+      true
+
+      iex> Ch.HTTP.to_deadline(:infinity)
+      :infinity
+
+      iex> Ch.HTTP.to_deadline({:deadline, 123})
+      {:deadline, 123}
+
   """
   @spec to_deadline(timeout | deadline) :: deadline
   def to_deadline(:infinity = inf), do: inf
@@ -26,6 +42,22 @@ defmodule Ch.HTTP do
 
   @doc """
   Returns the remaining milliseconds until a `t:deadline/0`.
+
+  ### Examples
+
+      iex> Ch.HTTP.to_timeout({:deadline, System.monotonic_time(:millisecond) + 1_000}) in 0..1_000
+      true
+
+      iex> {:deadline, deadline} = Ch.HTTP.to_timeout({:deadline, System.monotonic_time(:millisecond) + 1_000}) |> Ch.HTTP.to_deadline()
+      iex> is_integer(deadline)
+      true
+
+      iex> Ch.HTTP.to_timeout(:infinity)
+      :infinity
+
+      iex> Ch.HTTP.to_timeout(123)
+      123
+
   """
   @spec to_timeout(timeout | deadline) :: timeout
   def to_timeout(:infinity = inf), do: inf

--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -11,6 +11,28 @@ defmodule Ch.ConnectionTest do
     assert Ch.query!(pool, "select 1").rows == [[1]]
   end
 
+  test "validates pool options" do
+    assert {:ok, pool} = Ch.start_link(name: :ch_connection_test_pool)
+    Ch.stop(pool)
+
+    start_supervised!({Registry, keys: :unique, name: :ch_connection_test_registry})
+    via = {:via, Registry, {:ch_connection_test_registry, "pool"}}
+
+    assert {:ok, pool} = Ch.start_link(name: via)
+    Ch.stop(pool)
+
+    assert_raise NimbleOptions.ValidationError,
+                 ~s[invalid value for :name option: expected :name to be an atom or a {:via, module, term} tuple, got: "pool"],
+                 fn -> Ch.start_link(name: "pool") end
+
+    assert {:ok, pool} = Ch.start_link(url: "https://localhost:8123")
+    Ch.stop(pool)
+
+    assert_raise ArgumentError, "unexpected HTTP scheme: \"tcp\"", fn ->
+      Ch.start_link(url: "tcp://localhost:9000")
+    end
+  end
+
   test "selects with named params", %{pool: pool} do
     assert Ch.query!(pool, "select {a:UInt8}", %{"a" => 1}).rows == [[1]]
     assert Ch.query!(pool, "select {b:Bool}", %{"b" => true}).rows == [[true]]

--- a/test/ch/ecto_type_test.exs
+++ b/test/ch/ecto_type_test.exs
@@ -121,6 +121,8 @@ defmodule Ch.EctoTypeTest do
     assert {:ok, nil} = Ecto.Type.cast(type, nil)
 
     assert :error = Ecto.Type.cast(type, {42, "something"})
+    assert :error = Ecto.Type.cast(type, {"something"})
+    assert :error = Ecto.Type.cast(type, "something")
 
     assert {:ok, {"something", 42}} = Ecto.Type.dump(type, {"something", 42})
     assert {:ok, {"something", 42}} = Ecto.Type.load(type, {"something", 42})
@@ -231,7 +233,11 @@ defmodule Ch.EctoTypeTest do
     assert Ecto.Type.format(type) == "#Ch<Map(String, UInt64)>"
 
     assert {:ok, %{"answer" => 42}} = Ecto.Type.cast(type, %{"answer" => 42})
+    assert {:ok, %{"answer" => 42}} = Ecto.Type.cast(type, [{"answer", 42}])
     assert {:ok, nil} = Ecto.Type.cast(type, nil)
+    assert :error = Ecto.Type.cast(type, %{42 => 42})
+    assert :error = Ecto.Type.cast(type, [{"answer"}])
+    assert :error = Ecto.Type.cast(type, "answer")
 
     assert {:ok, %{"answer" => 42}} = Ecto.Type.dump(type, %{"answer" => 42})
     assert {:ok, %{"answer" => 42}} = Ecto.Type.load(type, %{"answer" => 42})

--- a/test/ch/http_test.exs
+++ b/test/ch/http_test.exs
@@ -1,0 +1,28 @@
+defmodule Ch.HTTPTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  doctest Ch.HTTP
+
+  property "timeout to deadline to timeout preserves the remaining timeout" do
+    check all timeout <- integer(0..60_000) do
+      round_tripped = timeout |> Ch.HTTP.to_deadline() |> Ch.HTTP.to_timeout()
+
+      assert round_tripped <= timeout
+      assert round_tripped >= max(timeout - 50, 0)
+    end
+  end
+
+  property "deadline to timeout to deadline preserves the absolute deadline" do
+    check all offset <- integer(0..60_000) do
+      deadline = {:deadline, System.monotonic_time(:millisecond) + offset}
+      {:deadline, original_timestamp} = deadline
+
+      {:deadline, round_tripped_timestamp} =
+        deadline |> Ch.HTTP.to_timeout() |> Ch.HTTP.to_deadline()
+
+      assert round_tripped_timestamp <= original_timestamp
+      assert round_tripped_timestamp >= original_timestamp - 50
+    end
+  end
+end

--- a/test/ch/query_string_test.exs
+++ b/test/ch/query_string_test.exs
@@ -135,7 +135,10 @@ defmodule Ch.QueryStringTest do
   end
 
   defp query_options do
-    uniq_list_of({safe_key(), one_of([integer(), boolean(), safe_string()])}, max_length: 8)
+    gen all options <-
+              map_of(safe_key(), one_of([integer(), boolean(), safe_string()]), max_length: 8) do
+      Map.to_list(options)
+    end
   end
 
   defp param do

--- a/test/ch/row_binary_test.exs
+++ b/test/ch/row_binary_test.exs
@@ -105,7 +105,45 @@ defmodule Ch.RowBinaryTest do
   end
 
   describe "encode/2" do
+    test "names and atom types" do
+      assert IO.iodata_to_binary(encode_names_and_types(["answer"], [:u8])) ==
+               <<1, 6, "answer", 5, "UInt8">>
+    end
+
+    test "encoding type aliases" do
+      assert encoding_types([{:datetime, "UTC"}]) == [:datetime]
+      assert encoding_types([{:datetime64, 6}]) == [datetime64: 1_000_000]
+      assert encoding_types([{:datetime64, 3, "UTC"}]) == [datetime64: 1000]
+      assert encoding_types([{:decimal, 9, 4}]) == [decimal32: 4]
+      assert encoding_types([{:decimal, 18, 4}]) == [decimal64: 4]
+      assert encoding_types([{:decimal, 38, 4}]) == [decimal128: 4]
+      assert encoding_types([{:decimal, 76, 4}]) == [decimal256: 4]
+      assert encoding_types([{:simple_aggregate_function, "any", :u8}]) == [:u8]
+
+      # See https://github.com/plausible/ch/issues/353
+      assert_raise ArgumentError,
+                   "can't encode DateTime with non-UTC timezone: \"Europe/Vienna\"",
+                   fn ->
+                     encoding_types([{:datetime, "Europe/Vienna"}])
+                   end
+
+      assert_raise ArgumentError,
+                   "can't encode DateTime64 with non-UTC timezone: \"Europe/Vienna\"",
+                   fn ->
+                     encoding_types([{:datetime64, 3, "Europe/Vienna"}])
+                   end
+
+      assert_raise ArgumentError, "unsupported type for encoding: :unsupported", fn ->
+        encoding_types([:unsupported])
+      end
+    end
+
     test "decimal" do
+      assert encode({:decimal, 9, 4}, Decimal.new("2.66")) == <<26600::32-little>>
+      assert encode({:decimal, 18, 4}, Decimal.new("2.66")) == <<26600::64-little>>
+      assert encode({:decimal, 38, 4}, Decimal.new("2.66")) == <<26600::128-little>>
+      assert encode({:decimal, 76, 4}, Decimal.new("2.66")) == <<26600::256-little>>
+
       type = {:decimal32, _scale = 4}
       assert encode(type, Decimal.new("2")) == <<20000::32-little>>
       assert encode(type, Decimal.new("2.66")) == <<26600::32-little>>
@@ -121,6 +159,10 @@ defmodule Ch.RowBinaryTest do
 
       hex = "d2bd5ec9-fdc5-a53f-32b5-e852f63a5f09"
       assert encode(:uuid, hex) == encode(:uuid, uuid)
+
+      uppercase = "12345678-9ABC-DEF0-1234-56789ABCDEF0"
+      raw = Base.decode16!("123456789ABCDEF0123456789ABCDEF0")
+      assert encode(:uuid, uppercase) == encode(:uuid, raw)
     end
 
     test "map" do
@@ -151,16 +193,45 @@ defmodule Ch.RowBinaryTest do
       assert encode(:date32, nil) == <<0, 0, 0, 0>>
       assert encode(:datetime, nil) == <<0, 0, 0, 0>>
       assert encode({:datetime64, :microsecond}, nil) == <<0, 0, 0, 0, 0, 0, 0, 0>>
+      assert encode(:time, nil) == <<0, 0, 0, 0>>
+      assert encode({:time64, 1_000}, nil) == <<0, 0, 0, 0, 0, 0, 0, 0>>
       assert encode(:uuid, nil) == <<0::128>>
       assert encode({:decimal32, _scale = 4}, nil) == <<0::32>>
       assert encode({:decimal64, _scale = 4}, nil) == <<0::64>>
       assert encode({:decimal128, _scale = 4}, nil) == <<0::128>>
       assert encode({:decimal256, _scale = 4}, nil) == <<0::256>>
+      assert encode(:ipv4, nil) == <<0::32>>
+      assert encode(:ipv6, nil) == <<0::128>>
       assert encode(:point, nil) == <<0::128>>
       assert encode(:ring, nil) == 0
       assert encode(:polygon, nil) == 0
       assert encode(:multipolygon, nil) == 0
       assert encode({:map, :string, :string}, nil) == 0
+      assert encode({:tuple, [:u8, :string]}, nil) == [0, 0]
+    end
+
+    test "ip addresses" do
+      assert encode(:ipv6, <<1::128>>) == <<1::128>>
+    end
+
+    test "dynamic empty list" do
+      assert encode(:dynamic, []) == [0x1E, 0x00]
+    end
+
+    test "enum missing value" do
+      assert_raise ArgumentError,
+                   ~s[enum value "missing" not found in mapping: %{"present" => 1}],
+                   fn -> encode({:enum8, %{"present" => 1}}, "missing") end
+    end
+
+    test "nullable scalar" do
+      assert encode({:nullable, :u8}, 1) == [0, 1]
+    end
+
+    test "variant without matching type" do
+      assert_raise ArgumentError, ~s[no matching type found for encoding "x" as Variant], fn ->
+        encode({:variant, [:u8]}, "x")
+      end
     end
   end
 
@@ -301,6 +372,13 @@ defmodule Ch.RowBinaryTest do
 
       assert decode_rows(payload) == [[nil, nil, 100.0]]
     end
+
+    test "returns continuation for incomplete enum rows" do
+      assert {[], "", {:cont, [{:enum8, %{1 => "one"}}], []}} =
+               decode_rows_continue("", [{:enum8, %{1 => "one"}}], nil)
+
+      assert {[], "", {:cont, [:u8], []}} = decode_rows_continue("", [:u8], nil)
+    end
   end
 
   describe "decode_rows/2" do
@@ -324,6 +402,12 @@ defmodule Ch.RowBinaryTest do
 
       assert_raise ArgumentError, expected_message, fn ->
         decode_rows(<<1>>, [:u8, :u8])
+      end
+    end
+
+    test "rejects unsupported decoded types" do
+      assert_raise ArgumentError, "unsupported type for decoding: :unsupported", fn ->
+        decode_rows(<<0>>, [:unsupported])
       end
     end
   end

--- a/test/ch/types_test.exs
+++ b/test/ch/types_test.exs
@@ -150,6 +150,7 @@ defmodule Ch.TypesTest do
 
     test "enum" do
       assert decode("Enum8('hello' = 1, 'world' = 2)") == {:enum8, [{"hello", 1}, {"world", 2}]}
+      assert decode("Enum8('é€𐍈' = 1)") == {:enum8, [{"é€𐍈", 1}]}
 
       assert decode("Enum16('hello' = -1, 'world' = 2)") ==
                {:enum16, [{"hello", -1}, {"world", 2}]}


### PR DESCRIPTION
## Summary

Adds focused tests for previously uncovered production branches in the ClickHouse client:

- RowBinary encode/decode edge coverage
- Ecto parameterized type map cast edge coverage
- Ch start option validation coverage through `start_link/1`
- HTTP deadline doctests plus round-trip property tests in `Ch.HTTPTest`
- a query option property generator fix so duplicate option keys do not make the property flaky

Follow-up issues opened from review:

- https://github.com/plausible/ch/issues/352
- https://github.com/plausible/ch/issues/353

## Validation

- `mix test test/ch/http_test.exs test/ch/connection_test.exs test/ch/row_binary_test.exs`
- `mix coveralls.json`

Final local coverage: 97.7% total, 234 tests, 27 properties, 171 doctests, 0 failures, 2 skipped.
