### PR TITLE
[codex] add scalar RowBinary integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Breaking:** `Ch.RowBinary` no longer has a separate `:binary` type. Use `:string` for ClickHouse `String`; it now preserves raw bytes and no longer replaces invalid UTF-8 with the replacement character.
 - Remove the `Jason` dependency. JSON encoding/decoding now uses Elixir's built-in `JSON` module.
 - Add explicit request and response compression support through HTTP headers. `zstd` and `gzip` response bodies are decompressed automatically for decoded `RowBinaryWithNamesAndTypes` and error responses; raw successful responses are kept as received in `Ch.Result.data`.
+- Fix `Time` query parameters inside arrays, tuples, and maps by quoting them as ClickHouse literals.
 - Fix `Time64` RowBinary encoding for precisions below microseconds.
 - Fix RowBinary integer encoders to reject out-of-range `Int16`/`UInt16` and wider values instead of silently wrapping, with added property coverage through 256-bit integer types.
 

--- a/lib/ch/http.ex
+++ b/lib/ch/http.ex
@@ -177,9 +177,9 @@ defmodule Ch.HTTP do
   defp encode_array_param(nil), do: "null"
 
   # DateTime64 array literals parse unquoted numbers as scaled ticks, while
-  # scalar query params parse the same text as seconds. Quote DateTime values so
+  # scalar query params parse the same text as seconds. Quote date/time values so
   # ClickHouse uses timestamp parsing inside arrays, tuples, and maps too.
-  defp encode_array_param(%s{} = param) when s in [Date, NaiveDateTime, DateTime] do
+  defp encode_array_param(%s{} = param) when s in [Date, Time, NaiveDateTime, DateTime] do
     [?', encode_param(param), ?']
   end
 

--- a/test/ch/dynamic_test.exs
+++ b/test/ch/dynamic_test.exs
@@ -1,5 +1,6 @@
 defmodule Ch.DynamicTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   @moduletag :dynamic
 
@@ -425,5 +426,62 @@ defmodule Ch.DynamicTest do
              [true, "Bool", true, "Bool", true],
              [[1, 2, 3], "Array(Int64)", [1, 2, 3], "Array(Int64)", true]
            ]
+  end
+
+  property "RowBinary Dynamic inserts round-trip supported encoded values", %{pool: pool} do
+    Help.query!("CREATE TABLE dynamic_test_property (id UInt64, d Dynamic) ENGINE = Memory;")
+    on_exit(fn -> Help.query!("DROP TABLE dynamic_test_property") end)
+
+    check all rows <- dynamic_rows(), max_runs: 25 do
+      Ch.query!(pool, "TRUNCATE TABLE dynamic_test_property")
+
+      rowbinary = Ch.RowBinary.encode_rows(rows, ["UInt64", "Dynamic"])
+      Ch.query!(pool, ["INSERT INTO dynamic_test_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM dynamic_test_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary Dynamic rejects unsupported encoded values" do
+    assert_raise CaseClauseError, fn ->
+      Ch.RowBinary.encode_rows([[true]], ["Dynamic"])
+    end
+
+    assert_raise CaseClauseError, fn ->
+      Ch.RowBinary.encode_rows([[%{"a" => 1}]], ["Dynamic"])
+    end
+  end
+
+  defp dynamic_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 12),
+            values <- list_of(dynamic_value(), length: length(ids)) do
+      Enum.zip_with(ids, values, fn id, value -> [id, value] end)
+    end
+  end
+
+  defp dynamic_value do
+    one_of([
+      string(:printable, max_length: 32),
+      integer(-9_007_199_254_740_992..9_007_199_254_740_991),
+      integer(-10_000..10_000) |> map(&(&1 * 1.0)),
+      date_gen(),
+      naive_datetime_gen()
+    ])
+  end
+
+  defp date_gen do
+    gen all days <- integer(0..20_000) do
+      Date.add(~D[1970-01-01], days)
+    end
+  end
+
+  defp naive_datetime_gen do
+    gen all date <- date_gen(),
+            hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59) do
+      NaiveDateTime.new!(date, Time.new!(hour, minute, second))
+    end
   end
 end

--- a/test/ch/json_test.exs
+++ b/test/ch/json_test.exs
@@ -1,5 +1,6 @@
 defmodule Ch.JSONTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   @moduletag :json
 
@@ -299,5 +300,67 @@ defmodule Ch.JSONTest do
         "SELECT json.a.b.:`Array(JSON)`.c, json.a.b.:`Array(JSON)`.f, json.a.b.:`Array(JSON)`.d FROM json_test;"
       )
     end
+  end
+
+  property "JSON values inserted as RowBinary round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("CREATE TABLE json_test_property (id UInt64, json JSON) ENGINE = Memory;")
+    on_exit(fn -> Help.query!("DROP TABLE json_test_property") end)
+
+    check all rows <- json_rows(), max_runs: 25 do
+      Ch.query!(pool, "TRUNCATE TABLE json_test_property")
+
+      rowbinary = Ch.RowBinary.encode_rows(rows, ["UInt64", "JSON"])
+
+      Ch.query!(
+        pool,
+        ["INSERT INTO json_test_property FORMAT RowBinary\n" | rowbinary],
+        _params = %{},
+        settings: %{"input_format_binary_read_json_as_string" => 1}
+      )
+
+      assert Ch.query!(
+               pool,
+               "SELECT id, json FROM json_test_property ORDER BY id",
+               _params = %{},
+               settings: %{"output_format_binary_write_json_as_string" => 1}
+             ).rows == Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary JSON rejects non-encodable values" do
+    assert_raise Protocol.UndefinedError, fn ->
+      Ch.RowBinary.encode_rows([[self()]], ["JSON"])
+    end
+  end
+
+  defp json_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 12),
+            values <- list_of(json_object(), length: length(ids)) do
+      Enum.zip_with(ids, values, fn id, value -> [id, value] end)
+    end
+  end
+
+  defp json_object do
+    map_of(
+      string(:alphanumeric, min_length: 1, max_length: 16),
+      json_value(),
+      min_length: 1,
+      max_length: 8
+    )
+  end
+
+  defp json_value do
+    one_of([
+      integer(-1_000_000..1_000_000),
+      string(:printable, max_length: 32),
+      boolean(),
+      list_of(integer(-1_000..1_000), min_length: 1, max_length: 8),
+      map_of(
+        string(:alphanumeric, min_length: 1, max_length: 16),
+        string(:printable, max_length: 32),
+        min_length: 1,
+        max_length: 4
+      )
+    ])
   end
 end

--- a/test/ch/query_string_test.exs
+++ b/test/ch/query_string_test.exs
@@ -402,7 +402,7 @@ defmodule Ch.QueryStringTest do
 
   defp expected_array_param(nil), do: "null"
 
-  defp expected_array_param(%value{} = param) when value in [Date, NaiveDateTime, DateTime],
+  defp expected_array_param(%value{} = param) when value in [Date, Time, NaiveDateTime, DateTime],
     do: "'" <> expected_param(param) <> "'"
 
   defp expected_array_param(value), do: expected_param(value)

--- a/test/ch/row_binary_aggregate_wrapper_test.exs
+++ b/test/ch/row_binary_aggregate_wrapper_test.exs
@@ -1,0 +1,111 @@
+defmodule Ch.RowBinaryAggregateWrapperTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "SimpleAggregateFunction values use the nested RowBinary encoding", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_simple_aggregate_property (
+      id UInt64,
+      max_int SimpleAggregateFunction(max, UInt64),
+      min_string SimpleAggregateFunction(min, String),
+      max_date SimpleAggregateFunction(max, Date)
+    ) ENGINE AggregatingMergeTree ORDER BY id
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_simple_aggregate_property") end)
+
+    check all rows <- simple_aggregate_rows(), max_runs: 20 do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_simple_aggregate_property")
+
+      types = [
+        "UInt64",
+        "SimpleAggregateFunction(max, UInt64)",
+        "SimpleAggregateFunction(min, String)",
+        "SimpleAggregateFunction(max, Date)"
+      ]
+
+      rowbinary = RowBinary.encode_rows(rows, types)
+
+      Ch.query!(pool, [
+        "INSERT INTO row_binary_simple_aggregate_property FORMAT RowBinary\n" | rowbinary
+      ])
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_simple_aggregate_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "AggregateFunction states can be populated from RowBinary input values", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_aggregate_function_values (
+      id UInt64,
+      updated SimpleAggregateFunction(max, DateTime),
+      name AggregateFunction(argMax, String, DateTime)
+    ) ENGINE AggregatingMergeTree ORDER BY id
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_aggregate_function_values") end)
+
+    rows = [
+      [1, ~N[2024-01-01 00:00:00], "old"],
+      [1, ~N[2024-01-02 00:00:00], "new"],
+      [2, ~N[2024-01-01 00:00:00], "only"]
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, ["UInt64", "DateTime", "String"])
+
+    Ch.query!(pool, [
+      """
+      INSERT INTO row_binary_aggregate_function_values
+        SELECT id, updated, arrayReduce('argMaxState', [name], [updated])
+        FROM input('id UInt64, updated DateTime, name String')
+        FORMAT RowBinary
+      """
+      | rowbinary
+    ])
+
+    assert Ch.query!(
+             pool,
+             """
+             SELECT id, max(updated), argMaxMerge(name)
+             FROM row_binary_aggregate_function_values
+             GROUP BY id
+             ORDER BY id
+             """
+           ).rows == [
+             [1, ~N[2024-01-02 00:00:00], "new"],
+             [2, ~N[2024-01-01 00:00:00], "only"]
+           ]
+  end
+
+  defp simple_aggregate_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 12),
+            values <-
+              list_of(
+                fixed_list([
+                  integer(0..18_446_744_073_709_551_615),
+                  safe_string(),
+                  date_gen()
+                ]),
+                length: length(ids)
+              ) do
+      Enum.zip_with(ids, values, fn id, values -> [id | values] end)
+    end
+  end
+
+  defp date_gen do
+    gen all days <- integer(0..20_000) do
+      Date.add(~D[1970-01-01], days)
+    end
+  end
+
+  defp safe_string do
+    string(:printable, max_length: 32)
+  end
+end

--- a/test/ch/row_binary_bool_test.exs
+++ b/test/ch/row_binary_bool_test.exs
@@ -1,0 +1,114 @@
+defmodule Ch.RowBinaryBoolTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  test "Bool params round-trip through ClickHouse", %{pool: pool} do
+    for value <- [true, false] do
+      assert Ch.query!(pool, "SELECT {value:Bool}", %{"value" => value}).rows == [[value]]
+    end
+  end
+
+  property "Bool arrays round-trip as query params through ClickHouse", %{pool: pool} do
+    check all values <- list_of(boolean(), max_length: 16) do
+      assert Ch.query!(pool, "SELECT {value:Array(Bool)}", %{"value" => values}).rows == [
+               [values]
+             ]
+    end
+  end
+
+  test "query params cover nullable and empty Bool arrays", %{pool: pool} do
+    assert Ch.query!(
+             pool,
+             "SELECT {t:Bool}, {f:Bool}, {n:Nullable(Bool)}, {empty:Array(Bool)}",
+             %{"t" => true, "f" => false, "n" => nil, "empty" => []}
+           ).rows == [[true, false, nil, []]]
+  end
+
+  property "invalid Bool params are rejected by ClickHouse", %{pool: pool} do
+    check all value <- invalid_bool_param() do
+      assert {:error, %Ch.Error{message: message}} =
+               Ch.query(pool, "SELECT {value:Bool}", %{"value" => value})
+
+      assert message =~ "Bool"
+    end
+  end
+
+  test "RowBinary Bool inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_bool_values (
+      id UInt64,
+      value Bool
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_bool_values") end)
+
+    rows = [
+      [0, false],
+      [1, true],
+      [18_446_744_073_709_551_615, false]
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, ["UInt64", "Bool"])
+    Ch.query!(pool, ["INSERT INTO row_binary_bool_values FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_bool_values ORDER BY id").rows == rows
+  end
+
+  test "RowBinary inserts cover nullable, arrays, tuples, maps, and defaults", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_bool_representative (
+      id UInt64,
+      value Bool,
+      nullable Nullable(Bool),
+      bools Array(Bool),
+      pair Tuple(Bool, Bool),
+      mapped Map(String, Bool)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_bool_representative") end)
+
+    rows = [
+      [1, true, nil, [], {true, false}, %{}],
+      [2, false, true, [true, false, true], {false, true}, %{"a" => true, "b" => false}],
+      [18_446_744_073_709_551_615, nil, false, [false], {true, true}, %{"zero" => false}]
+    ]
+
+    types = [
+      "UInt64",
+      "Bool",
+      "Nullable(Bool)",
+      "Array(Bool)",
+      "Tuple(Bool, Bool)",
+      "Map(String, Bool)"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+    Ch.query!(pool, ["INSERT INTO row_binary_bool_representative FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_bool_representative ORDER BY id").rows == [
+             [1, true, nil, [], {true, false}, %{}],
+             [2, false, true, [true, false, true], {false, true}, %{"a" => true, "b" => false}],
+             [18_446_744_073_709_551_615, false, false, [false], {true, true}, %{"zero" => false}]
+           ]
+  end
+
+  test "RowBinary rejects invalid Bool values" do
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["true"]], ["Bool"])
+    end
+  end
+
+  defp invalid_bool_param do
+    gen all suffix <- string(:alphanumeric, min_length: 1, max_length: 16) do
+      "not_bool_#{suffix}"
+    end
+  end
+end

--- a/test/ch/row_binary_date_time_test.exs
+++ b/test/ch/row_binary_date_time_test.exs
@@ -1,0 +1,382 @@
+defmodule Ch.RowBinaryDateTimeTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "Date and Date32 params round-trip through ClickHouse", %{pool: pool} do
+    check all {type, value} <- date_param() do
+      assert Ch.query!(pool, "SELECT {value:#{type}}", %{"value" => value}).rows == [[value]]
+    end
+  end
+
+  property "DateTime and DateTime64 params round-trip through ClickHouse", %{pool: pool} do
+    check all {type, value, expected} <- datetime_param() do
+      assert Ch.query!(pool, "SELECT {value:#{type}}", %{"value" => value}).rows == [[expected]]
+    end
+  end
+
+  @tag :time
+  property "Time and Time64 params round-trip through ClickHouse", %{pool: pool} do
+    check all {type, value, expected} <- time_param() do
+      assert Ch.query!(pool, "SELECT {value:#{type}}", %{"value" => value}).rows == [[expected]]
+    end
+  end
+
+  test "query params cover nullable, arrays, and deterministic date/time cases", %{pool: pool} do
+    assert Ch.query!(
+             pool,
+             """
+             SELECT
+               {date:Date},
+               {date32:Date32},
+               {datetime:DateTime('UTC')},
+               {datetime64:DateTime64(6, 'UTC')},
+               {nullable:Nullable(Date)},
+               {dates:Array(Date)}
+             """,
+             %{
+               "date" => ~D[2024-02-29],
+               "date32" => ~D[1960-01-01],
+               "datetime" => ~U[2024-01-02 03:04:05Z],
+               "datetime64" => ~U[2024-01-02 03:04:05.123456Z],
+               "nullable" => nil,
+               "dates" => [~D[1970-01-01], ~D[2024-02-29]]
+             }
+           ).rows == [
+             [
+               ~D[2024-02-29],
+               ~D[1960-01-01],
+               ~U[2024-01-02 03:04:05Z],
+               ~U[2024-01-02 03:04:05.123456Z],
+               nil,
+               [~D[1970-01-01], ~D[2024-02-29]]
+             ]
+           ]
+  end
+
+  @tag :time
+  test "query params cover deterministic Time and Time64 cases", %{pool: pool} do
+    assert Ch.query!(
+             pool,
+             """
+             SELECT
+              {time:Time},
+               {time64_0:Time64(0)},
+               {time64_3:Time64(3)},
+               {time64_6:Time64(6)},
+               {times:Array(Time64(3))}
+             """,
+             %{
+               "time" => ~T[12:34:56],
+               "time64_0" => ~T[12:34:56.987654],
+               "time64_3" => ~T[12:34:56.987654],
+               "time64_6" => ~T[12:34:56.987654],
+               "times" => [~T[00:00:00.987654], ~T[23:59:59.999999]]
+             }
+           ).rows == [
+             [
+               ~T[12:34:56],
+               ~T[12:34:56],
+               ~T[12:34:56.987],
+               ~T[12:34:56.987654],
+               [~T[00:00:00.987], ~T[23:59:59.999]]
+             ]
+           ]
+  end
+
+  property "RowBinary Date and DateTime inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_date_time_property (
+      id UInt8,
+      d Date,
+      d32 Date32,
+      dt DateTime('UTC'),
+      dt64 DateTime64(6, 'UTC')
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_date_time_property") end)
+
+    check all rows <- rowbinary_date_time_rows() do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_date_time_property")
+
+      rowbinary =
+        RowBinary.encode_rows(
+          rows,
+          ["UInt8", "Date", "Date32", "DateTime('UTC')", "DateTime64(6, 'UTC')"]
+        )
+
+      Ch.query!(pool, ["INSERT INTO row_binary_date_time_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_date_time_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  @tag :time
+  property "RowBinary Time inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_time_property (
+      id UInt8,
+      t Time,
+      t64_0 Time64(0),
+      t64_3 Time64(3),
+      t64_6 Time64(6)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_time_property") end)
+
+    check all rows <- rowbinary_time_rows() do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_time_property")
+
+      rowbinary =
+        RowBinary.encode_rows(rows, ["UInt8", "Time", "Time64(0)", "Time64(3)", "Time64(6)"])
+
+      Ch.query!(pool, ["INSERT INTO row_binary_time_property FORMAT RowBinary\n" | rowbinary])
+
+      expected =
+        rows
+        |> Enum.map(fn [id, t, t64_0, t64_3, t64_6] ->
+          [id, truncate_time(t, 0), truncate_time(t64_0, 0), truncate_time(t64_3, 3), t64_6]
+        end)
+        |> Enum.sort_by(&List.first/1)
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_time_property ORDER BY id").rows ==
+               expected
+    end
+  end
+
+  test "RowBinary inserts cover nullable, arrays, tuples, and defaults", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_date_time_representative (
+      id UInt8,
+      d Date,
+      nullable_date Nullable(Date),
+      dates Array(Date),
+      dt DateTime('UTC'),
+      dt64 DateTime64(6, 'UTC'),
+      pair Tuple(Date, DateTime('UTC'))
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_date_time_representative") end)
+
+    rows = [
+      [
+        1,
+        ~D[1970-01-01],
+        nil,
+        [],
+        ~U[1970-01-01 00:00:00Z],
+        ~U[1970-01-01 00:00:00.000001Z],
+        {~D[2024-02-29], ~U[2024-01-02 03:04:05Z]}
+      ],
+      [
+        2,
+        nil,
+        ~D[2024-02-29],
+        [~D[1970-01-01], ~D[2024-02-29]],
+        ~U[2024-01-02 03:04:05Z],
+        ~U[2024-01-02 03:04:05.123456Z],
+        {~D[1970-01-01], ~U[1970-01-01 00:00:00Z]}
+      ]
+    ]
+
+    types = [
+      "UInt8",
+      "Date",
+      "Nullable(Date)",
+      "Array(Date)",
+      "DateTime('UTC')",
+      "DateTime64(6, 'UTC')",
+      "Tuple(Date, DateTime('UTC'))"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+
+    Ch.query!(pool, [
+      "INSERT INTO row_binary_date_time_representative FORMAT RowBinary\n" | rowbinary
+    ])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_date_time_representative ORDER BY id").rows ==
+             [
+               [
+                 1,
+                 ~D[1970-01-01],
+                 nil,
+                 [],
+                 ~U[1970-01-01 00:00:00Z],
+                 ~U[1970-01-01 00:00:00.000001Z],
+                 {~D[2024-02-29], ~U[2024-01-02 03:04:05Z]}
+               ],
+               [
+                 2,
+                 ~D[1970-01-01],
+                 ~D[2024-02-29],
+                 [~D[1970-01-01], ~D[2024-02-29]],
+                 ~U[2024-01-02 03:04:05Z],
+                 ~U[2024-01-02 03:04:05.123456Z],
+                 {~D[1970-01-01], ~U[1970-01-01 00:00:00Z]}
+               ]
+             ]
+  end
+
+  test "RowBinary rejects invalid date/time values" do
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["2024-01-01"]], ["Date"])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["2024-01-01 00:00:00"]], ["DateTime('UTC')"])
+    end
+  end
+
+  defp date_param do
+    one_of([
+      typed_value("Date", date_gen()),
+      typed_value("Date32", date32_gen())
+    ])
+  end
+
+  defp datetime_param do
+    one_of([
+      typed_datetime("DateTime('UTC')", utc_datetime(), 0),
+      typed_datetime("DateTime64(0, 'UTC')", utc_datetime64(), 0),
+      typed_datetime("DateTime64(3, 'UTC')", utc_datetime64(), 3),
+      typed_datetime("DateTime64(6, 'UTC')", utc_datetime64(), 6)
+    ])
+  end
+
+  defp time_param do
+    one_of([
+      typed_time("Time", time_second_gen(), 0),
+      typed_time("Time64(0)", time_gen(), 0),
+      typed_time("Time64(3)", time_gen(), 3),
+      typed_time("Time64(6)", time_gen(), 6)
+    ])
+  end
+
+  defp typed_value(type, generator) do
+    gen all value <- generator do
+      {type, value}
+    end
+  end
+
+  defp typed_datetime(type, generator, precision) do
+    gen all value <- generator do
+      {type, value, truncate_datetime(value, precision)}
+    end
+  end
+
+  defp typed_time(type, generator, precision) do
+    gen all value <- generator do
+      {type, value, truncate_time(value, precision)}
+    end
+  end
+
+  defp rowbinary_date_time_rows do
+    gen all ids <- uniq_list_of(integer(0..255), max_length: 12),
+            values <-
+              list_of(
+                fixed_list([
+                  date_gen(),
+                  date32_gen(),
+                  utc_datetime(),
+                  utc_datetime64()
+                ]),
+                length: length(ids)
+              ) do
+      Enum.zip_with(ids, values, fn id, values -> [id | values] end)
+    end
+  end
+
+  defp rowbinary_time_rows do
+    gen all ids <- uniq_list_of(integer(0..255), max_length: 12),
+            values <-
+              list_of(
+                fixed_list([
+                  time_gen(),
+                  time_gen(),
+                  time_gen(),
+                  time_gen()
+                ]),
+                length: length(ids)
+              ) do
+      Enum.zip_with(ids, values, fn id, values -> [id | values] end)
+    end
+  end
+
+  defp date_gen do
+    gen all days <- integer(0..20_000) do
+      Date.add(~D[1970-01-01], days)
+    end
+  end
+
+  defp date32_gen do
+    gen all days <- integer(-25_567..120_529) do
+      Date.add(~D[1970-01-01], days)
+    end
+  end
+
+  defp utc_datetime do
+    gen all date <- date_gen(),
+            hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59) do
+      DateTime.new!(date, Time.new!(hour, minute, second), "Etc/UTC")
+    end
+  end
+
+  defp utc_datetime64 do
+    gen all date <- date_gen(),
+            hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59),
+            microsecond <- integer(0..999_999) do
+      DateTime.new!(date, Time.new!(hour, minute, second, {microsecond, 6}), "Etc/UTC")
+    end
+  end
+
+  defp time_gen do
+    gen all hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59),
+            microsecond <- integer(0..999_999) do
+      Time.new!(hour, minute, second, {microsecond, 6})
+    end
+  end
+
+  defp time_second_gen do
+    gen all hour <- integer(0..23),
+            minute <- integer(0..59),
+            second <- integer(0..59) do
+      Time.new!(hour, minute, second)
+    end
+  end
+
+  defp truncate_datetime(datetime, 6), do: datetime
+
+  defp truncate_datetime(datetime, precision) do
+    {microsecond, _} = datetime.microsecond
+    scale = Integer.pow(10, 6 - precision)
+    microsecond = div(microsecond, scale) * scale
+
+    %{datetime | microsecond: {microsecond, precision}}
+  end
+
+  defp truncate_time(time, 6), do: time
+
+  defp truncate_time(time, precision) do
+    {microsecond, _} = time.microsecond
+    scale = Integer.pow(10, 6 - precision)
+    microsecond = div(microsecond, scale) * scale
+
+    %{time | microsecond: {microsecond, precision}}
+  end
+end

--- a/test/ch/row_binary_decimal_test.exs
+++ b/test/ch/row_binary_decimal_test.exs
@@ -1,0 +1,201 @@
+defmodule Ch.RowBinaryDecimalTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "decimal params round-trip through ClickHouse across storage widths", %{pool: pool} do
+    check all {type, value, expected} <- decimal_param() do
+      assert Ch.query!(pool, "SELECT {value:#{type}}", %{"value" => value}).rows == [[expected]]
+    end
+  end
+
+  property "decimal arrays round-trip as query params through ClickHouse", %{pool: pool} do
+    check all {type, values, expected} <- decimal_array_param() do
+      assert Ch.query!(pool, "SELECT {value:Array(#{type})}", %{"value" => values}).rows == [
+               [expected]
+             ]
+    end
+  end
+
+  test "query params cover deterministic decimal precisions", %{pool: pool} do
+    cases = [
+      {"Decimal32(4)", Decimal.new("0"), Decimal.new("0.0000")},
+      {"Decimal32(4)", Decimal.new("12345.6789"), Decimal.new("12345.6789")},
+      {"Decimal64(6)", Decimal.new("-123456789.123456"), Decimal.new("-123456789.123456")},
+      {"Decimal128(9)", Decimal.new("123456789012345678.123456789"),
+       Decimal.new("123456789012345678.123456789")},
+      {"Decimal256(18)",
+       Decimal.new(-1, 123_456_789_012_345_678_901_234_567_890_123_456_789, -18),
+       Decimal.new(-1, 123_456_789_012_345_678_901_234_567_890_123_456_789, -18)}
+    ]
+
+    for {type, value, expected} <- cases do
+      assert Ch.query!(pool, "SELECT {value:#{type}}", %{"value" => value}).rows == [[expected]]
+    end
+  end
+
+  test "nullable, empty array, and invalid decimal params through ClickHouse", %{pool: pool} do
+    assert Ch.query!(
+             pool,
+             "SELECT {nullable:Nullable(Decimal(18, 4))}, {empty:Array(Decimal(18, 4))}",
+             %{"nullable" => nil, "empty" => []}
+           ).rows == [[nil, []]]
+
+    assert {:error, %Ch.Error{message: message}} =
+             Ch.query(pool, "SELECT {value:Decimal(18, 4)}", %{"value" => "not-a-decimal"})
+
+    assert message =~ "Decimal"
+  end
+
+  property "RowBinary decimal inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_decimal_property (
+      id UInt8,
+      d32 Decimal32(4),
+      d64 Decimal64(6),
+      d128 Decimal128(9),
+      d256 Decimal256(18)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_decimal_property") end)
+
+    check all rows <- rowbinary_decimal_rows(), max_runs: 20 do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_decimal_property")
+
+      rowbinary =
+        RowBinary.encode_rows(
+          rows,
+          ["UInt8", "Decimal32(4)", "Decimal64(6)", "Decimal128(9)", "Decimal256(18)"]
+        )
+
+      Ch.query!(pool, ["INSERT INTO row_binary_decimal_property FORMAT RowBinary\n" | rowbinary])
+
+      expected = Enum.sort_by(rows, &List.first/1)
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_decimal_property ORDER BY id").rows ==
+               expected
+    end
+  end
+
+  test "RowBinary inserts cover nullable, arrays, tuples, and defaults", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_decimal_representative (
+      id UInt8,
+      d Decimal(18, 4),
+      nullable Nullable(Decimal(18, 4)),
+      decimals Array(Decimal(18, 4)),
+      pair Tuple(Decimal(9, 2), Decimal(18, 4))
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_decimal_representative") end)
+
+    rows = [
+      [1, Decimal.new("1.23"), nil, [], {Decimal.new("1.2"), Decimal.new("-2.3456")}],
+      [
+        2,
+        nil,
+        Decimal.new("-4.56789"),
+        [Decimal.new("0"), Decimal.new("123.45678")],
+        {Decimal.new("99.999"), Decimal.new("42")}
+      ]
+    ]
+
+    types = [
+      "UInt8",
+      "Decimal(18, 4)",
+      "Nullable(Decimal(18, 4))",
+      "Array(Decimal(18, 4))",
+      "Tuple(Decimal(9, 2), Decimal(18, 4))"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+
+    Ch.query!(pool, [
+      "INSERT INTO row_binary_decimal_representative FORMAT RowBinary\n" | rowbinary
+    ])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_decimal_representative ORDER BY id").rows ==
+             [
+               [
+                 1,
+                 Decimal.new("1.2300"),
+                 nil,
+                 [],
+                 {Decimal.new("1.20"), Decimal.new("-2.3456")}
+               ],
+               [
+                 2,
+                 Decimal.new("0.0000"),
+                 Decimal.new("-4.5679"),
+                 [Decimal.new("0.0000"), Decimal.new("123.4568")],
+                 {Decimal.new("100.00"), Decimal.new("42.0000")}
+               ]
+             ]
+  end
+
+  test "RowBinary rejects invalid decimal values" do
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["1.23"]], ["Decimal(18, 4)"])
+    end
+  end
+
+  defp decimal_param do
+    one_of([
+      typed_decimal("Decimal32(4)", decimal_gen(5, 4)),
+      typed_decimal("Decimal64(6)", decimal_gen(12, 6)),
+      typed_decimal("Decimal128(9)", decimal_gen(20, 9)),
+      typed_decimal("Decimal256(18)", decimal_gen(30, 18))
+    ])
+  end
+
+  defp decimal_array_param do
+    one_of([
+      typed_decimal_array("Decimal32(4)", decimal_gen(5, 4)),
+      typed_decimal_array("Decimal64(6)", decimal_gen(12, 6)),
+      typed_decimal_array("Decimal128(9)", decimal_gen(20, 9)),
+      typed_decimal_array("Decimal256(18)", decimal_gen(30, 18))
+    ])
+  end
+
+  defp typed_decimal(type, generator) do
+    gen all value <- generator do
+      {type, value, value}
+    end
+  end
+
+  defp typed_decimal_array(type, generator) do
+    gen all values <- list_of(generator, max_length: 4) do
+      {type, values, values}
+    end
+  end
+
+  defp rowbinary_decimal_rows do
+    gen all ids <- uniq_list_of(integer(0..255), max_length: 12),
+            values <-
+              list_of(
+                fixed_list([
+                  decimal_gen(5, 4),
+                  decimal_gen(12, 6),
+                  decimal_gen(20, 9),
+                  decimal_gen(30, 18)
+                ]),
+                length: length(ids)
+              ) do
+      Enum.zip_with(ids, values, fn id, decimals -> [id | decimals] end)
+    end
+  end
+
+  defp decimal_gen(integer_digits, scale) do
+    gen all sign <- member_of([1, -1]),
+            coefficient <- integer(0..(Integer.pow(10, integer_digits + scale) - 1)) do
+      Decimal.new(sign, coefficient, -scale)
+    end
+  end
+end

--- a/test/ch/row_binary_enum_test.exs
+++ b/test/ch/row_binary_enum_test.exs
@@ -1,0 +1,97 @@
+defmodule Ch.RowBinaryEnumTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  @enum8 "Enum8('low' = -1, 'zero' = 0, 'high' = 1)"
+  @enum16 "Enum16('small' = -129, 'medium' = 0, 'large' = 128)"
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "Enum params round-trip through ClickHouse", %{pool: pool} do
+    check all {type, value} <- enum_param() do
+      assert Ch.query!(pool, "SELECT {value:#{type}}", %{"value" => value}).rows == [[value]]
+    end
+  end
+
+  property "Enum arrays round-trip as query params through ClickHouse", %{pool: pool} do
+    check all {type, values} <- enum_array_param() do
+      assert Ch.query!(pool, "SELECT {value:Array(#{type})}", %{"value" => values}).rows == [
+               [values]
+             ]
+    end
+  end
+
+  test "RowBinary Enum inserts accept names and integer values", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_enum_values (
+      id UInt64,
+      e8 #{@enum8},
+      e16 #{@enum16},
+      e8s Array(#{@enum8}),
+      maybe Nullable(#{@enum16})
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_enum_values") end)
+
+    rows = [
+      [0, "low", "small", ["low", "zero", "high"], nil],
+      [1, 0, 0, [-1, 0, 1], "medium"],
+      [18_446_744_073_709_551_615, 1, 128, ["high"], -129]
+    ]
+
+    types = ["UInt64", @enum8, @enum16, "Array(#{@enum8})", "Nullable(#{@enum16})"]
+    rowbinary = RowBinary.encode_rows(rows, types)
+    Ch.query!(pool, ["INSERT INTO row_binary_enum_values FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_enum_values ORDER BY id").rows == [
+             [0, "low", "small", ["low", "zero", "high"], nil],
+             [1, "zero", "medium", ["low", "zero", "high"], "medium"],
+             [18_446_744_073_709_551_615, "high", "large", ["high"], "small"]
+           ]
+  end
+
+  test "RowBinary rejects missing enum names and out-of-range enum values" do
+    assert_raise ArgumentError, ~r/enum value "missing" not found/, fn ->
+      RowBinary.encode_rows([["missing"]], [@enum8])
+    end
+
+    assert_raise ArgumentError, "invalid Int8: 128", fn ->
+      RowBinary.encode_rows([[128]], [@enum8])
+    end
+
+    assert_raise ArgumentError, "invalid Int16: 32768", fn ->
+      RowBinary.encode_rows([[32_768]], [@enum16])
+    end
+  end
+
+  defp enum_param do
+    one_of([
+      typed_enum(@enum8, member_of(["low", "zero", "high"])),
+      typed_enum(@enum16, member_of(["small", "medium", "large"]))
+    ])
+  end
+
+  defp enum_array_param do
+    one_of([
+      typed_enum_array(@enum8, member_of(["low", "zero", "high"])),
+      typed_enum_array(@enum16, member_of(["small", "medium", "large"]))
+    ])
+  end
+
+  defp typed_enum(type, generator) do
+    gen all value <- generator do
+      {type, value}
+    end
+  end
+
+  defp typed_enum_array(type, generator) do
+    gen all values <- list_of(generator, max_length: 8) do
+      {type, values}
+    end
+  end
+end

--- a/test/ch/row_binary_geo_test.exs
+++ b/test/ch/row_binary_geo_test.exs
@@ -1,0 +1,76 @@
+defmodule Ch.RowBinaryGeoTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "Point params round-trip through ClickHouse", %{pool: pool} do
+    check all point <- point_gen() do
+      assert [[decoded]] = Ch.query!(pool, "SELECT {value:Point}", %{"value" => point}).rows
+      assert_in_delta elem(decoded, 0), elem(point, 0), 1.0e-9
+      assert_in_delta elem(decoded, 1), elem(point, 1), 1.0e-9
+    end
+  end
+
+  property "RowBinary Point inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("CREATE TABLE row_binary_geo_point_property(id UInt64, p Point) ENGINE Memory")
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_geo_point_property") end)
+
+    check all rows <- point_rows(), max_runs: 25 do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_geo_point_property")
+
+      rowbinary = RowBinary.encode_rows(rows, ["UInt64", "Point"])
+
+      Ch.query!(pool, ["INSERT INTO row_binary_geo_point_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_geo_point_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary inserts cover Ring, Polygon, and MultiPolygon aliases", %{pool: pool} do
+    Help.query!(
+      "CREATE TABLE row_binary_geo_values(id UInt64, r Ring, p Polygon, mp MultiPolygon) ENGINE Memory"
+    )
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_geo_values") end)
+
+    ring = [{0.0, 0.0}, {10.0, 0.0}, {10.0, 10.0}, {0.0, 10.0}]
+    polygon = [ring, [{2.0, 2.0}, {4.0, 2.0}, {4.0, 4.0}]]
+    multipolygon = [polygon, [[{20.0, 20.0}, {30.0, 20.0}, {30.0, 30.0}]]]
+
+    rows = [
+      [0, [], [], []],
+      [1, ring, polygon, multipolygon]
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, ["UInt64", "Ring", "Polygon", "MultiPolygon"])
+    Ch.query!(pool, ["INSERT INTO row_binary_geo_values FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_geo_values ORDER BY id").rows == rows
+  end
+
+  test "RowBinary rejects invalid Point values" do
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["not a point"]], ["Point"])
+    end
+  end
+
+  defp point_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 16),
+            points <- list_of(point_gen(), length: length(ids)) do
+      Enum.zip_with(ids, points, fn id, point -> [id, point] end)
+    end
+  end
+
+  defp point_gen do
+    gen all x <- integer(-1_000_000..1_000_000),
+            y <- integer(-1_000_000..1_000_000) do
+      {x * 1.0, y * 1.0}
+    end
+  end
+end

--- a/test/ch/row_binary_low_cardinality_test.exs
+++ b/test/ch/row_binary_low_cardinality_test.exs
@@ -1,0 +1,134 @@
+defmodule Ch.RowBinaryLowCardinalityTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "LowCardinality params round-trip through ClickHouse", %{pool: pool} do
+    check all {type, value, expected} <- low_cardinality_param() do
+      assert Ch.query!(pool, "SELECT {value:LowCardinality(#{type})}", %{"value" => value}).rows ==
+               [[expected]]
+    end
+  end
+
+  property "RowBinary LowCardinality inserts use the nested encoding", %{pool: pool} do
+    Ch.query!(
+      pool,
+      """
+      CREATE TABLE row_binary_low_cardinality_property (
+        id UInt64,
+        string LowCardinality(String),
+        fixed LowCardinality(FixedString(4)),
+        int LowCardinality(UInt64)
+      ) ENGINE Memory
+      """,
+      %{},
+      settings: %{"allow_suspicious_low_cardinality_types" => 1}
+    )
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_low_cardinality_property") end)
+
+    check all rows <- rowbinary_low_cardinality_rows(), max_runs: 25 do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_low_cardinality_property")
+
+      types = [
+        "UInt64",
+        "LowCardinality(String)",
+        "LowCardinality(FixedString(4))",
+        "LowCardinality(UInt64)"
+      ]
+
+      rowbinary = RowBinary.encode_rows(rows, types)
+
+      Ch.query!(pool, [
+        "INSERT INTO row_binary_low_cardinality_property FORMAT RowBinary\n" | rowbinary
+      ])
+
+      expected =
+        rows
+        |> Enum.map(fn [id, string, fixed, int] ->
+          [id, string, fixed <> :binary.copy(<<0>>, 4 - byte_size(fixed)), int]
+        end)
+        |> Enum.sort_by(&List.first/1)
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_low_cardinality_property ORDER BY id").rows ==
+               expected
+    end
+  end
+
+  test "LowCardinality arrays round-trip through ClickHouse", %{pool: pool} do
+    Ch.query!(
+      pool,
+      """
+      CREATE TABLE row_binary_low_cardinality_representative (
+        id UInt64,
+        strings Array(LowCardinality(String)),
+        ints Array(LowCardinality(UInt64))
+      ) ENGINE Memory
+      """,
+      %{},
+      settings: %{"allow_suspicious_low_cardinality_types" => 1}
+    )
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_low_cardinality_representative") end)
+
+    rows = [
+      [0, [], []],
+      [1, ["a", "b", "a"], [0, 1, 1, 2]]
+    ]
+
+    types = [
+      "UInt64",
+      "Array(LowCardinality(String))",
+      "Array(LowCardinality(UInt64))"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+
+    Ch.query!(pool, [
+      "INSERT INTO row_binary_low_cardinality_representative FORMAT RowBinary\n" | rowbinary
+    ])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_low_cardinality_representative ORDER BY id").rows ==
+             rows
+  end
+
+  defp low_cardinality_param do
+    one_of([
+      typed_param("String", safe_string(), & &1),
+      typed_param("FixedString(4)", binary(max_length: 4), fn value ->
+        value <> :binary.copy(<<0>>, 4 - byte_size(value))
+      end),
+      typed_param("UInt64", integer(0..9_007_199_254_740_991), & &1)
+    ])
+  end
+
+  defp typed_param(type, generator, expected_fun) do
+    gen all value <- generator do
+      {type, value, expected_fun.(value)}
+    end
+  end
+
+  defp rowbinary_low_cardinality_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 12),
+            values <-
+              list_of(
+                fixed_list([
+                  safe_string(),
+                  binary(max_length: 4),
+                  integer(0..9_007_199_254_740_991)
+                ]),
+                length: length(ids)
+              ) do
+      Enum.zip_with(ids, values, fn id, values -> [id | values] end)
+    end
+  end
+
+  defp safe_string do
+    string(:printable, max_length: 32)
+  end
+end

--- a/test/ch/row_binary_map_test.exs
+++ b/test/ch/row_binary_map_test.exs
@@ -1,0 +1,102 @@
+defmodule Ch.RowBinaryMapTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "Map params round-trip through ClickHouse", %{pool: pool} do
+    check all map <- map_of(safe_key(), integer(0..255), max_length: 8) do
+      assert Ch.query!(pool, "SELECT {value:Map(String, UInt8)}", %{"value" => map}).rows == [
+               [map]
+             ]
+    end
+  end
+
+  property "RowBinary Map inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_map_property (
+      id UInt64,
+      value Map(String, UInt8)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_map_property") end)
+
+    check all rows <- rowbinary_map_rows(), max_runs: 25 do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_map_property")
+
+      rowbinary = RowBinary.encode_rows(rows, ["UInt64", "Map(String, UInt8)"])
+      Ch.query!(pool, ["INSERT INTO row_binary_map_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_map_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary Map inserts cover nested and nullable values", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_map_representative (
+      id UInt64,
+      strings Map(String, String),
+      nullable_strings Map(String, Nullable(String)),
+      arrays Map(String, Array(UInt8)),
+      tuple_values Map(String, Tuple(UInt8, Bool))
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_map_representative") end)
+
+    rows = [
+      [0, %{}, %{}, %{}, %{}],
+      [
+        1,
+        %{"a" => "b"},
+        %{"present" => "value", "missing" => nil},
+        %{"nums" => [1, 2, 3], "empty" => []},
+        %{"one" => {1, true}, "zero" => {0, false}}
+      ]
+    ]
+
+    types = [
+      "UInt64",
+      "Map(String, String)",
+      "Map(String, Nullable(String))",
+      "Map(String, Array(UInt8))",
+      "Map(String, Tuple(UInt8, Bool))"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+    Ch.query!(pool, ["INSERT INTO row_binary_map_representative FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_map_representative ORDER BY id").rows == rows
+  end
+
+  test "RowBinary accepts key-value lists and rejects invalid map values" do
+    assert IO.iodata_to_binary(RowBinary.encode({:map, :string, :u8}, [{"a", 1}, {"b", 2}])) ==
+             IO.iodata_to_binary(RowBinary.encode({:map, :string, :u8}, [{"a", 1}, {"b", 2}]))
+
+    assert_raise CaseClauseError, fn ->
+      RowBinary.encode({:map, :string, :u8}, a: 1)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["not a map"]], ["Map(String, UInt8)"])
+    end
+  end
+
+  defp rowbinary_map_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 16),
+            maps <-
+              list_of(map_of(safe_key(), integer(0..255), max_length: 8), length: length(ids)) do
+      Enum.zip_with(ids, maps, fn id, map -> [id, map] end)
+    end
+  end
+
+  defp safe_key do
+    string(:alphanumeric, min_length: 1, max_length: 16)
+  end
+end

--- a/test/ch/row_binary_network_test.exs
+++ b/test/ch/row_binary_network_test.exs
@@ -1,0 +1,209 @@
+defmodule Ch.RowBinaryNetworkTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "IPv4 params accept text and decode to tuples", %{pool: pool} do
+    check all {text, tuple} <- ipv4_param() do
+      assert Ch.query!(pool, "SELECT {value:IPv4}, toString({value:IPv4})", %{
+               "value" => text
+             }).rows == [[tuple, text]]
+    end
+  end
+
+  property "IPv6 params accept text and decode to tuples", %{pool: pool} do
+    check all {text, tuple, canonical} <- ipv6_param() do
+      assert Ch.query!(pool, "SELECT {value:IPv6}, toString({value:IPv6})", %{
+               "value" => text
+             }).rows == [[tuple, canonical]]
+    end
+  end
+
+  property "network arrays round-trip as query params through ClickHouse", %{pool: pool} do
+    check all ipv4s <- list_of(ipv4_param(), max_length: 8),
+              ipv6s <- list_of(ipv6_param(), max_length: 8) do
+      ipv4_texts = Enum.map(ipv4s, fn {text, _tuple} -> text end)
+      ipv4_tuples = Enum.map(ipv4s, fn {_text, tuple} -> tuple end)
+      ipv6_texts = Enum.map(ipv6s, fn {text, _tuple, _canonical} -> text end)
+      ipv6_tuples = Enum.map(ipv6s, fn {_text, tuple, _canonical} -> tuple end)
+
+      assert Ch.query!(
+               pool,
+               "SELECT {ipv4s:Array(IPv4)}, {ipv6s:Array(IPv6)}",
+               %{"ipv4s" => ipv4_texts, "ipv6s" => ipv6_texts}
+             ).rows == [[ipv4_tuples, ipv6_tuples]]
+    end
+  end
+
+  test "query params cover nullable, empty arrays, and invalid network values", %{pool: pool} do
+    assert Ch.query!(
+             pool,
+             """
+             SELECT
+               {ipv4:IPv4},
+               {ipv6:IPv6},
+               {nullable4:Nullable(IPv4)},
+               {nullable6:Nullable(IPv6)},
+               {empty4:Array(IPv4)},
+               {empty6:Array(IPv6)}
+             """,
+             %{
+               "ipv4" => "127.0.0.1",
+               "ipv6" => "::1",
+               "nullable4" => nil,
+               "nullable6" => nil,
+               "empty4" => [],
+               "empty6" => []
+             }
+           ).rows == [[{127, 0, 0, 1}, {0, 0, 0, 0, 0, 0, 0, 1}, nil, nil, [], []]]
+
+    assert {:error, %Ch.Error{message: message}} =
+             Ch.query(pool, "SELECT {value:IPv4}", %{"value" => "999.0.0.1"})
+
+    assert message =~ "IPv4"
+
+    assert {:error, %Ch.Error{message: message}} =
+             Ch.query(pool, "SELECT {value:IPv6}", %{"value" => "not-ipv6"})
+
+    assert message =~ "IPv6"
+  end
+
+  property "RowBinary network inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_network_property (
+      id UInt8,
+      ipv4 IPv4,
+      ipv6 IPv6
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_network_property") end)
+
+    check all rows <- rowbinary_network_rows() do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_network_property")
+
+      rowbinary = RowBinary.encode_rows(rows, ["UInt8", "IPv4", "IPv6"])
+      Ch.query!(pool, ["INSERT INTO row_binary_network_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_network_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary inserts cover nullable, arrays, tuples, and defaults", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_network_representative (
+      id UInt8,
+      ipv4 IPv4,
+      ipv6 IPv6,
+      nullable4 Nullable(IPv4),
+      nullable6 Nullable(IPv6),
+      ipv4s Array(IPv4),
+      ipv6s Array(IPv6),
+      pair Tuple(IPv4, IPv6)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_network_representative") end)
+
+    ipv4_1 = {127, 0, 0, 1}
+    ipv4_2 = {192, 168, 1, 1}
+    ipv6_1 = {0, 0, 0, 0, 0, 0, 0, 1}
+    ipv6_2 = {0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888}
+
+    rows = [
+      [1, ipv4_1, ipv6_1, nil, nil, [], [], {ipv4_1, ipv6_1}],
+      [2, nil, nil, ipv4_2, ipv6_2, [ipv4_1, ipv4_2], [ipv6_1, ipv6_2], {ipv4_2, ipv6_2}]
+    ]
+
+    types = [
+      "UInt8",
+      "IPv4",
+      "IPv6",
+      "Nullable(IPv4)",
+      "Nullable(IPv6)",
+      "Array(IPv4)",
+      "Array(IPv6)",
+      "Tuple(IPv4, IPv6)"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+
+    Ch.query!(pool, [
+      "INSERT INTO row_binary_network_representative FORMAT RowBinary\n" | rowbinary
+    ])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_network_representative ORDER BY id").rows ==
+             [
+               [1, ipv4_1, ipv6_1, nil, nil, [], [], {ipv4_1, ipv6_1}],
+               [
+                 2,
+                 {0, 0, 0, 0},
+                 {0, 0, 0, 0, 0, 0, 0, 0},
+                 ipv4_2,
+                 ipv6_2,
+                 [ipv4_1, ipv4_2],
+                 [ipv6_1, ipv6_2],
+                 {ipv4_2, ipv6_2}
+               ]
+             ]
+  end
+
+  test "RowBinary rejects invalid network values" do
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["127.0.0.1"]], ["IPv4"])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["::1"]], ["IPv6"])
+    end
+  end
+
+  defp rowbinary_network_rows do
+    gen all ids <- uniq_list_of(integer(0..255), max_length: 16),
+            ipv4s <- list_of(ipv4_tuple(), length: length(ids)),
+            ipv6s <- list_of(ipv6_tuple(), length: length(ids)) do
+      Enum.zip_with([ids, ipv4s, ipv6s], fn [id, ipv4, ipv6] -> [id, ipv4, ipv6] end)
+    end
+  end
+
+  defp ipv4_param do
+    gen all tuple <- ipv4_tuple() do
+      {tuple |> :inet.ntoa() |> to_string(), tuple}
+    end
+  end
+
+  defp ipv6_param do
+    gen all tuple <- ipv6_tuple() do
+      canonical = tuple |> :inet.ntoa() |> to_string()
+      {canonical, tuple, canonical}
+    end
+  end
+
+  defp ipv4_tuple do
+    gen all a <- integer(0..255),
+            b <- integer(0..255),
+            c <- integer(0..255),
+            d <- integer(0..255) do
+      {a, b, c, d}
+    end
+  end
+
+  defp ipv6_tuple do
+    gen all a <- integer(0..65_535),
+            b <- integer(0..65_535),
+            c <- integer(0..65_535),
+            d <- integer(0..65_535),
+            e <- integer(0..65_535),
+            f <- integer(0..65_535),
+            g <- integer(0..65_535),
+            h <- integer(0..65_535) do
+      {a, b, c, d, e, f, g, h}
+    end
+  end
+end

--- a/test/ch/row_binary_nullable_test.exs
+++ b/test/ch/row_binary_nullable_test.exs
@@ -1,0 +1,103 @@
+defmodule Ch.RowBinaryNullableTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "Nullable params round-trip through ClickHouse", %{pool: pool} do
+    check all {type, value, expected} <- nullable_param() do
+      assert Ch.query!(pool, "SELECT {value:Nullable(#{type})}", %{"value" => value}).rows == [
+               [expected]
+             ]
+    end
+  end
+
+  property "arrays of Nullable params round-trip through ClickHouse", %{pool: pool} do
+    check all {type, values, expected} <- nullable_array_param() do
+      assert Ch.query!(pool, "SELECT {value:Array(Nullable(#{type}))}", %{"value" => values}).rows ==
+               [[expected]]
+    end
+  end
+
+  test "RowBinary Nullable inserts cover present and null values", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_nullable_values (
+      id UInt64,
+      maybe_string Nullable(String),
+      maybe_int Nullable(Int32),
+      maybe_bool Nullable(Bool),
+      maybe_date Nullable(Date),
+      maybe_tuple Tuple(Nullable(String), Nullable(UInt8)),
+      maybe_strings Array(Nullable(String))
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_nullable_values") end)
+
+    rows = [
+      [0, nil, nil, nil, nil, {nil, nil}, []],
+      [1, "hello", -1, true, ~D[2024-02-29], {"tuple", 1}, ["a", nil, "b"]],
+      [18_446_744_073_709_551_615, "", 0, false, ~D[1970-01-01], {"", 0}, [nil]]
+    ]
+
+    types = [
+      "UInt64",
+      "Nullable(String)",
+      "Nullable(Int32)",
+      "Nullable(Bool)",
+      "Nullable(Date)",
+      "Tuple(Nullable(String), Nullable(UInt8))",
+      "Array(Nullable(String))"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+    Ch.query!(pool, ["INSERT INTO row_binary_nullable_values FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_nullable_values ORDER BY id").rows == rows
+  end
+
+  defp nullable_param do
+    one_of([
+      typed_nullable("String", one_of([constant(nil), safe_string()])),
+      typed_nullable("Int32", one_of([constant(nil), integer(-2_147_483_648..2_147_483_647)])),
+      typed_nullable("UInt8", one_of([constant(nil), integer(0..255)])),
+      typed_nullable("Bool", one_of([constant(nil), boolean()])),
+      typed_nullable("Date", one_of([constant(nil), date_gen()]))
+    ])
+  end
+
+  defp nullable_array_param do
+    one_of([
+      typed_nullable_array("String", one_of([constant(nil), safe_string()])),
+      typed_nullable_array("UInt8", one_of([constant(nil), integer(0..255)])),
+      typed_nullable_array("Bool", one_of([constant(nil), boolean()])),
+      typed_nullable_array("Date", one_of([constant(nil), date_gen()]))
+    ])
+  end
+
+  defp typed_nullable(type, generator) do
+    gen all value <- generator do
+      {type, value, value}
+    end
+  end
+
+  defp typed_nullable_array(type, generator) do
+    gen all values <- list_of(generator, max_length: 8) do
+      {type, values, values}
+    end
+  end
+
+  defp date_gen do
+    gen all days <- integer(0..20_000) do
+      Date.add(~D[1970-01-01], days)
+    end
+  end
+
+  defp safe_string do
+    string(:printable, max_length: 32)
+  end
+end

--- a/test/ch/row_binary_tuple_test.exs
+++ b/test/ch/row_binary_tuple_test.exs
@@ -1,0 +1,117 @@
+defmodule Ch.RowBinaryTupleTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "Tuple params round-trip through ClickHouse", %{pool: pool} do
+    check all tuple <- tuple_param() do
+      assert Ch.query!(pool, "SELECT {value:Tuple(String, UInt8, Bool)}", %{"value" => tuple}).rows ==
+               [[tuple]]
+    end
+  end
+
+  property "arrays of Tuple params round-trip through ClickHouse", %{pool: pool} do
+    check all tuples <- list_of(tuple_param(), max_length: 8) do
+      assert Ch.query!(pool, "SELECT {value:Array(Tuple(String, UInt8, Bool))}", %{
+               "value" => tuples
+             }).rows == [[tuples]]
+    end
+  end
+
+  property "RowBinary Tuple inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_tuple_property (
+      id UInt64,
+      value Tuple(String, UInt8, Bool)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_tuple_property") end)
+
+    check all rows <- rowbinary_tuple_rows(), max_runs: 25 do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_tuple_property")
+
+      rowbinary = RowBinary.encode_rows(rows, ["UInt64", "Tuple(String, UInt8, Bool)"])
+      Ch.query!(pool, ["INSERT INTO row_binary_tuple_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_tuple_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary Tuple inserts cover nested containers and nil defaults", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_tuple_representative (
+      id UInt64,
+      simple Tuple(String, UInt8),
+      nested Tuple(Array(UInt8), Map(String, Nullable(String))),
+      tuple_array Array(Tuple(String, UInt8))
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_tuple_representative") end)
+
+    rows = [
+      [0, {"", 0}, {[], %{}}, []],
+      [
+        1,
+        {"one", 1},
+        {[1, 2, 3], %{"a" => "b", "nil" => nil}},
+        [{"a", 1}, {"b", 2}]
+      ],
+      [18_446_744_073_709_551_615, nil, {[], %{"x" => nil}}, [{"max", 255}]]
+    ]
+
+    types = [
+      "UInt64",
+      "Tuple(String, UInt8)",
+      "Tuple(Array(UInt8), Map(String, Nullable(String)))",
+      "Array(Tuple(String, UInt8))"
+    ]
+
+    rowbinary = RowBinary.encode_rows(rows, types)
+
+    Ch.query!(pool, ["INSERT INTO row_binary_tuple_representative FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_tuple_representative ORDER BY id").rows == [
+             [0, {"", 0}, {[], %{}}, []],
+             [
+               1,
+               {"one", 1},
+               {[1, 2, 3], %{"a" => "b", "nil" => nil}},
+               [{"a", 1}, {"b", 2}]
+             ],
+             [18_446_744_073_709_551_615, {"", 0}, {[], %{"x" => nil}}, [{"max", 255}]]
+           ]
+  end
+
+  test "RowBinary rejects tuple values with missing elements" do
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["not a tuple"]], ["Tuple(String, UInt8)"])
+    end
+  end
+
+  defp rowbinary_tuple_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 16),
+            tuples <- list_of(tuple_param(), length: length(ids)) do
+      Enum.zip_with(ids, tuples, fn id, tuple -> [id, tuple] end)
+    end
+  end
+
+  defp tuple_param do
+    gen all string <- safe_string(),
+            int <- integer(0..255),
+            bool <- boolean() do
+      {string, int, bool}
+    end
+  end
+
+  defp safe_string do
+    string(:printable, max_length: 32)
+  end
+end

--- a/test/ch/row_binary_uuid_test.exs
+++ b/test/ch/row_binary_uuid_test.exs
@@ -1,0 +1,134 @@
+defmodule Ch.RowBinaryUUIDTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Ch.RowBinary
+
+  setup do
+    {:ok, pool: start_supervised!(Ch)}
+  end
+
+  property "UUID params accept canonical text and decode to bytes", %{pool: pool} do
+    check all {text, bytes} <- uuid_param() do
+      assert Ch.query!(pool, "SELECT {value:UUID}, toString({value:UUID})", %{
+               "value" => text
+             }).rows == [[bytes, text]]
+    end
+  end
+
+  property "UUID arrays round-trip as query params through ClickHouse", %{pool: pool} do
+    check all values <- list_of(uuid_param(), max_length: 8) do
+      texts = Enum.map(values, fn {text, _bytes} -> text end)
+      bytes = Enum.map(values, fn {_text, bytes} -> bytes end)
+
+      assert Ch.query!(pool, "SELECT {value:Array(UUID)}", %{"value" => texts}).rows == [
+               [bytes]
+             ]
+    end
+  end
+
+  test "query params cover uppercase text, nil, empty arrays, and invalid UUIDs", %{pool: pool} do
+    uuid = "417ddc5d-e556-4d27-95dd-a34d84e46a50"
+    uppercase = String.upcase(uuid)
+    bytes = uuid_to_binary(uuid)
+
+    assert Ch.query!(
+             pool,
+             "SELECT {uuid:UUID}, toString({uuid:UUID}), {nullable:Nullable(UUID)}, {empty:Array(UUID)}",
+             %{"uuid" => uppercase, "nullable" => nil, "empty" => []}
+           ).rows == [[bytes, uuid, nil, []]]
+
+    assert {:error, %Ch.Error{message: message}} =
+             Ch.query(pool, "SELECT {value:UUID}", %{"value" => "not-a-uuid"})
+
+    assert message =~ "UUID"
+  end
+
+  property "RowBinary UUID inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_uuid_property (
+      id UInt8,
+      value UUID
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_uuid_property") end)
+
+    check all rows <- rowbinary_uuid_rows() do
+      Ch.query!(pool, "TRUNCATE TABLE row_binary_uuid_property")
+
+      rowbinary = RowBinary.encode_rows(rows, ["UInt8", "UUID"])
+      Ch.query!(pool, ["INSERT INTO row_binary_uuid_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM row_binary_uuid_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary inserts cover nullable, arrays, tuples, and defaults", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE row_binary_uuid_representative (
+      id UInt8,
+      value UUID,
+      nullable Nullable(UUID),
+      uuids Array(UUID),
+      pair Tuple(UUID, UUID)
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE row_binary_uuid_representative") end)
+
+    uuid1 = uuid_to_binary("417ddc5d-e556-4d27-95dd-a34d84e46a50")
+    uuid2 = uuid_to_binary("00010203-0405-0607-0809-0a0b0c0d0e0f")
+
+    rows = [
+      [1, uuid1, nil, [], {uuid1, uuid2}],
+      [2, nil, uuid2, [uuid1, uuid2], {uuid2, uuid1}]
+    ]
+
+    types = ["UInt8", "UUID", "Nullable(UUID)", "Array(UUID)", "Tuple(UUID, UUID)"]
+    rowbinary = RowBinary.encode_rows(rows, types)
+    Ch.query!(pool, ["INSERT INTO row_binary_uuid_representative FORMAT RowBinary\n" | rowbinary])
+
+    assert Ch.query!(pool, "SELECT * FROM row_binary_uuid_representative ORDER BY id").rows == [
+             [1, uuid1, nil, [], {uuid1, uuid2}],
+             [2, <<0::128>>, uuid2, [uuid1, uuid2], {uuid2, uuid1}]
+           ]
+  end
+
+  test "RowBinary rejects invalid UUID values" do
+    assert_raise FunctionClauseError, fn ->
+      RowBinary.encode_rows([["not-a-uuid"]], ["UUID"])
+    end
+  end
+
+  defp rowbinary_uuid_rows do
+    gen all ids <- uniq_list_of(integer(0..255), max_length: 16),
+            values <- list_of(uuid_bytes(), length: length(ids)) do
+      Enum.zip_with(ids, values, fn id, value -> [id, value] end)
+    end
+  end
+
+  defp uuid_param do
+    gen all bytes <- uuid_bytes() do
+      <<a::binary-size(4), b::binary-size(2), c::binary-size(2), d::binary-size(2),
+        e::binary-size(6)>> = bytes
+
+      text =
+        [a, b, c, d, e]
+        |> Enum.map_join("-", &Base.encode16(&1, case: :lower))
+
+      {text, bytes}
+    end
+  end
+
+  defp uuid_bytes do
+    binary(length: 16)
+  end
+
+  defp uuid_to_binary(uuid) do
+    uuid
+    |> String.replace("-", "")
+    |> Base.decode16!(case: :lower)
+  end
+end

--- a/test/ch/variant_test.exs
+++ b/test/ch/variant_test.exs
@@ -1,5 +1,6 @@
 defmodule Ch.VariantTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   # https://clickhouse.com/docs/sql-reference/data-types/variant
 
@@ -98,5 +99,59 @@ defmodule Ch.VariantTest do
     Ch.query!(pool, ["INSERT INTO variant_test_rowbinary FORMAT RowBinary\n" | rowbinary])
 
     assert Ch.query!(pool, "SELECT v FROM variant_test_rowbinary").rows == rows
+  end
+
+  property "RowBinary Variant inserts round-trip through ClickHouse", %{pool: pool} do
+    Help.query!("""
+    CREATE TABLE variant_test_property (
+      id UInt64,
+      v Variant(UInt64, String, Array(UInt64), Map(String, String))
+    ) ENGINE Memory
+    """)
+
+    on_exit(fn -> Help.query!("DROP TABLE variant_test_property") end)
+
+    check all rows <- variant_rows(), max_runs: 25 do
+      Ch.query!(pool, "TRUNCATE TABLE variant_test_property")
+
+      rowbinary =
+        Ch.RowBinary.encode_rows(
+          rows,
+          ["UInt64", "Variant(UInt64, String, Array(UInt64), Map(String, String))"]
+        )
+
+      Ch.query!(pool, ["INSERT INTO variant_test_property FORMAT RowBinary\n" | rowbinary])
+
+      assert Ch.query!(pool, "SELECT * FROM variant_test_property ORDER BY id").rows ==
+               Enum.sort_by(rows, &List.first/1)
+    end
+  end
+
+  test "RowBinary Variant rejects values that match no branch" do
+    assert_raise ArgumentError, ~s[no matching type found for encoding true as Variant], fn ->
+      Ch.RowBinary.encode_rows([[true]], ["Variant(UInt64, String, Array(UInt64))"])
+    end
+  end
+
+  defp variant_rows do
+    gen all ids <- uniq_list_of(integer(0..18_446_744_073_709_551_615), max_length: 12),
+            values <- list_of(variant_value(), length: length(ids)) do
+      Enum.zip_with(ids, values, fn id, value -> [id, value] end)
+    end
+  end
+
+  defp variant_value do
+    one_of([
+      constant(nil),
+      integer(0..9_007_199_254_740_991),
+      string(:printable, min_length: 1, max_length: 32),
+      list_of(integer(0..9_007_199_254_740_991), min_length: 1, max_length: 8),
+      map_of(
+        string(:alphanumeric, min_length: 1, max_length: 16),
+        string(:printable, max_length: 32),
+        min_length: 1,
+        max_length: 8
+      )
+    ])
   end
 end


### PR DESCRIPTION
Adds dedicated ClickHouse-backed RowBinary integration tests for decimals, bools, dates/times, UUIDs, and network types.

The tests cover query parameters, arrays, nullable values, representative nested containers, invalid values, and RowBinary inserts.

This also quotes Time values inside array/tuple/map query parameters so ClickHouse can parse Time and Time64 literals with colons.

Validated with `mix test test/ch/row_binary_decimal_test.exs test/ch/row_binary_bool_test.exs test/ch/row_binary_date_time_test.exs test/ch/row_binary_uuid_test.exs test/ch/row_binary_network_test.exs test/ch/query_string_test.exs`.