### PR TITLE
[codex] add predefined RowBinary encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,19 @@ Ch.query!(
   headers: [{"content-encoding", "zstd"}]
 )
 ```
+
+For hot insert paths, define the schema once and generate an encoder:
+
+```elixir
+defmodule DemoInsert do
+  require Ch.RowBinary
+
+  Ch.RowBinary.define_encoder(
+    schema: [id: "UInt64", text: "String"],
+    name: :encode_insert,
+    table: "demo"
+  )
+end
+
+Ch.query!(pool, DemoInsert.encode_insert([%{id: 1, text: "one"}]))
+```

--- a/bench/encode.exs
+++ b/bench/encode.exs
@@ -5,7 +5,25 @@ This benchmark measures the performance of encoding rows in RowBinary format.
 alias Ch.Bench.RowBinaryBenchmarkData
 alias Ch.RowBinary
 
+defmodule PredefinedRowBinaryEncoder do
+  require Ch.RowBinary
+
+  Ch.RowBinary.define_encoder(
+    schema: Ch.Bench.RowBinaryBenchmarkData.schema(),
+    name: :encode_many,
+    rows: true
+  )
+
+  Ch.RowBinary.define_encoder(
+    schema: Ch.Bench.RowBinaryBenchmarkData.schema(),
+    name: :insert_many,
+    table: "benchmark"
+  )
+end
+
 types = RowBinaryBenchmarkData.types()
+fields = RowBinaryBenchmarkData.fields()
+encoding_types = RowBinary.encoding_types(types)
 
 formatters =
   Enum.reject(
@@ -21,18 +39,34 @@ formatters =
 
 Benchee.run(
   %{
-    "RowBinary" => fn rows -> RowBinary.encode_rows(rows, types) end,
-    "RowBinary stream of 100k row chunks" => fn rows ->
-      types = RowBinary.encoding_types(types)
+    "RowBinary row lists" => fn %{rows: rows} ->
+      RowBinary._encode_rows(rows, encoding_types)
+    end,
+    "RowBinary atom maps via fields" => fn %{row_maps: row_maps} ->
+      rows =
+        Enum.map(row_maps, fn row ->
+          Enum.map(fields, fn field -> Map.fetch!(row, field) end)
+        end)
 
-      Stream.chunk_every(rows, 100_000)
-      |> Stream.each(fn chunk -> RowBinary._encode_rows(chunk, types) end)
+      RowBinary._encode_rows(rows, encoding_types)
+    end,
+    "Predefined atom map encoder" => fn %{row_maps: row_maps} ->
+      PredefinedRowBinaryEncoder.encode_many(row_maps)
+    end,
+    "Predefined full insert body" => fn %{row_maps: row_maps} ->
+      PredefinedRowBinaryEncoder.insert_many(row_maps)
+    end,
+    "Predefined atom map encoder stream of 100k row chunks" => fn %{row_maps: row_maps} ->
+      Stream.chunk_every(row_maps, 100_000)
+      |> Stream.each(fn chunk -> PredefinedRowBinaryEncoder.encode_many(chunk) end)
       |> Stream.run()
     end
   },
+  before_scenario: fn count ->
+    %{rows: RowBinaryBenchmarkData.rows(count), row_maps: RowBinaryBenchmarkData.row_maps(count)}
+  end,
   inputs: %{
-    "1_000_000 (UInt64, String, Array(UInt8), DateTime64(3, 'UTC'), DateTime) rows" =>
-      RowBinaryBenchmarkData.rows(1_000_000)
+    "1_000_000 (UInt64, String, Array(UInt8), DateTime64(3, 'UTC'), DateTime) rows" => 1_000_000
   },
   formatters: formatters
 )

--- a/dev/support/row_binary_benchmark_data.ex
+++ b/dev/support/row_binary_benchmark_data.ex
@@ -1,12 +1,22 @@
 defmodule Ch.Bench.RowBinaryBenchmarkData do
   alias Ch.RowBinary
 
-  @types ["UInt64", "String", "Array(UInt8)", "DateTime64(3, 'UTC')", "DateTime"]
+  @schema [
+    id: "UInt64",
+    title: "String",
+    bytes: "Array(UInt8)",
+    timestamp64: "DateTime64(3, 'UTC')",
+    inserted_at: "DateTime"
+  ]
+  @fields Keyword.keys(@schema)
+  @types Keyword.values(@schema)
   @titles ["Golang SQL database driver", "Phoenix app event", "billing webhook payload"]
   @bytes Enum.to_list(1..16)
   @base_datetime DateTime.from_naive!(~N[2026-01-01 00:00:00.000], "Etc/UTC")
   @base_naive ~N[2026-01-01 00:00:00]
 
+  def schema, do: @schema
+  def fields, do: @fields
   def types, do: @types
 
   def rows(count) do
@@ -18,6 +28,18 @@ defmodule Ch.Bench.RowBinaryBenchmarkData do
         DateTime.add(@base_datetime, i * 17, :millisecond),
         NaiveDateTime.add(@base_naive, i, :second)
       ]
+    end)
+  end
+
+  def row_maps(count) do
+    Enum.map(1..count, fn i ->
+      %{
+        id: i,
+        title: Enum.at(@titles, rem(i, length(@titles))),
+        bytes: Enum.take(@bytes, rem(i, length(@bytes)) + 1),
+        timestamp64: DateTime.add(@base_datetime, i * 17, :millisecond),
+        inserted_at: NaiveDateTime.add(@base_naive, i, :second)
+      }
     end)
   end
 

--- a/lib/ch/row_binary.ex
+++ b/lib/ch/row_binary.ex
@@ -27,6 +27,451 @@ defmodule Ch.RowBinary do
   defp encode_types([] = done), do: done
 
   @doc """
+  Defines a specialized RowBinary encoder function at compile time.
+
+  The generated function normalizes the ClickHouse types once during
+  compilation and emits direct encoding code for common scalar, string,
+  nullable, and `Array(UInt8)` columns. Complex types still fall back to
+  `encode/2`.
+
+  By default, the generated function encodes one atom-keyed row map or struct:
+
+      defmodule Events do
+        require Ch.RowBinary
+
+        Ch.RowBinary.define_encoder(
+          schema: [id: "UInt64", name: "String"],
+          name: :encode_row
+        )
+      end
+
+      Events.encode_row(%{id: 1, name: "home"})
+
+  String keys pattern match string-keyed maps:
+
+      Ch.RowBinary.define_encoder(
+        schema: %{"id" => "UInt64", "name" => "String"},
+        name: :encode_row
+      )
+
+  Pass `rows: true` to define a function that encodes many rows. Pass `:table`
+  to define a many-row function that returns a full
+  `INSERT ... FORMAT RowBinaryWithNamesAndTypes` request body with the header
+  precomputed.
+  """
+  defmacro define_encoder(opts_ast) do
+    caller = __CALLER__
+    opts = compile_time_value!(opts_ast, caller, :options)
+
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "expected define_encoder options to be a keyword list"
+    end
+
+    build_encoder_definition(opts)
+  end
+
+  defmacro define_encoder(name_ast, opts_ast) do
+    caller = __CALLER__
+    name = compile_time_value!(name_ast, caller, :name)
+    opts = compile_time_value!(opts_ast, caller, :options)
+
+    unless is_atom(name) do
+      raise ArgumentError, "expected encoder name to be an atom, got: #{inspect(name)}"
+    end
+
+    unless Keyword.keyword?(opts) do
+      raise ArgumentError, "expected define_encoder options to be a keyword list"
+    end
+
+    opts =
+      case Keyword.fetch(opts, :name) do
+        {:ok, ^name} ->
+          opts
+
+        {:ok, other} ->
+          raise ArgumentError, "conflicting encoder names: #{inspect(name)} and #{inspect(other)}"
+
+        :error ->
+          Keyword.put(opts, :name, name)
+      end
+
+    build_encoder_definition(opts)
+  end
+
+  defp compile_time_value!(ast, caller, label) do
+    {value, _binding} = Code.eval_quoted(ast, [], caller)
+    value
+  rescue
+    _e ->
+      reraise ArgumentError,
+              [
+                message:
+                  "expected define_encoder #{label} to be available at compile time, got: #{Macro.to_string(ast)}"
+              ],
+              __STACKTRACE__
+  end
+
+  defp build_encoder_definition(opts) do
+    name = Keyword.fetch!(opts, :name)
+    schema = Keyword.fetch!(opts, :schema)
+
+    unless is_atom(name) do
+      raise ArgumentError, "expected encoder name to be an atom, got: #{inspect(name)}"
+    end
+
+    columns = encoder_columns!(schema)
+    rows? = Keyword.get(opts, :rows, Keyword.has_key?(opts, :table))
+    table = Keyword.get(opts, :table)
+
+    {pattern, row_iodata} = encoder_row(columns)
+
+    cond do
+      table ->
+        rows_fun = encoder_private_name(name, :rows)
+        prefix = insert_prefix!(table, columns)
+
+        quote do
+          def unquote(name)(rows) do
+            [unquote(prefix) | unquote(rows_fun)(rows)]
+          end
+
+          defp unquote(rows_fun)([unquote(pattern) | rows]) do
+            [unquote(row_iodata) | unquote(rows_fun)(rows)]
+          end
+
+          defp unquote(rows_fun)([]), do: []
+        end
+
+      rows? ->
+        rows_fun = encoder_private_name(name, :rows)
+
+        quote do
+          def unquote(name)(rows) do
+            unquote(rows_fun)(rows)
+          end
+
+          defp unquote(rows_fun)([unquote(pattern) | rows]) do
+            [unquote(row_iodata) | unquote(rows_fun)(rows)]
+          end
+
+          defp unquote(rows_fun)([]), do: []
+        end
+
+      true ->
+        quote do
+          def unquote(name)(unquote(pattern)) do
+            unquote(row_iodata)
+          end
+        end
+    end
+  end
+
+  defp encoder_private_name(name, suffix) do
+    :"__ch_rowbinary_#{name}_#{suffix}__"
+  end
+
+  defp insert_prefix!(table, columns) when is_atom(table) do
+    insert_prefix!(Atom.to_string(table), columns)
+  end
+
+  defp insert_prefix!(table, columns) when is_binary(table) do
+    names =
+      Enum.map(columns, fn {_key, column_name, _type, _encoding_type, _var} -> column_name end)
+
+    types = Enum.map(columns, fn {_key, _column_name, type, _encoding_type, _var} -> type end)
+
+    IO.iodata_to_binary([
+      "INSERT INTO ",
+      table,
+      " FORMAT RowBinaryWithNamesAndTypes\n",
+      encode_names_and_types(names, types)
+    ])
+  end
+
+  defp insert_prefix!(table, _columns) do
+    raise ArgumentError, "expected :table to be a string or atom, got: #{inspect(table)}"
+  end
+
+  defp encoder_columns!(schema) when is_map(schema) do
+    schema
+    |> Map.to_list()
+    |> Enum.sort_by(fn {key, _type} -> column_name!(key) end)
+    |> encoder_columns!()
+  end
+
+  defp encoder_columns!(schema) when is_list(schema) do
+    Enum.with_index(schema, fn
+      {key, type}, index ->
+        column_name = column_name!(key)
+        var = Macro.var(:"column_#{index}", nil)
+        {key, column_name, type, encoding_type(type), var}
+
+      other, _index ->
+        raise ArgumentError,
+              "expected schema entries to be {name, type} pairs, got: #{inspect(other)}"
+    end)
+  end
+
+  defp encoder_columns!(schema) do
+    raise ArgumentError, "expected :schema to be a map or list, got: #{inspect(schema)}"
+  end
+
+  defp column_name!(key) when is_binary(key), do: key
+  defp column_name!(key) when is_atom(key), do: Atom.to_string(key)
+
+  defp column_name!(key) do
+    raise ArgumentError, "expected schema keys to be strings or atoms, got: #{inspect(key)}"
+  end
+
+  defp encoder_row(columns) do
+    pattern =
+      {:%{}, [],
+       Enum.map(columns, fn {key, _column_name, _type, _encoding_type, var} ->
+         {key, var}
+       end)}
+
+    row_iodata =
+      Enum.map(columns, fn {_key, _column_name, _type, encoding_type, var} ->
+        encoder_expr(encoding_type, var)
+      end)
+
+    {pattern, row_iodata}
+  end
+
+  defp encoder_expr(:string, value) do
+    quote do
+      case unquote(value) do
+        string when is_binary(string) ->
+          [Ch.RowBinary.encode_varint(byte_size(string)) | string]
+
+        iodata when is_list(iodata) ->
+          [Ch.RowBinary.encode_varint(IO.iodata_length(iodata)) | iodata]
+
+        nil ->
+          0
+      end
+    end
+  end
+
+  defp encoder_expr(:boolean, value) do
+    quote do
+      case unquote(value) do
+        true -> 1
+        false -> 0
+        nil -> 0
+      end
+    end
+  end
+
+  defp encoder_expr(:u8, value) do
+    quote do
+      case unquote(value) do
+        u when is_integer(u) and u >= 0 and u <= 255 -> u
+        nil -> 0
+        term -> raise ArgumentError, "invalid UInt8: #{inspect(term)}"
+      end
+    end
+  end
+
+  defp encoder_expr(:i8, value) do
+    quote do
+      case unquote(value) do
+        i when is_integer(i) and i >= 0 and i <= 127 -> i
+        i when is_integer(i) and i < 0 and i >= -128 -> <<i::signed>>
+        nil -> 0
+        term -> raise ArgumentError, "invalid Int8: #{inspect(term)}"
+      end
+    end
+  end
+
+  for size <- [16, 32, 64, 128, 256] do
+    uint = :"u#{size}"
+    int = :"i#{size}"
+    unsigned_max = (1 <<< size) - 1
+    signed_min = -(1 <<< (size - 1))
+    signed_max = (1 <<< (size - 1)) - 1
+
+    defp encoder_expr(unquote(uint), value) do
+      size = unquote(size)
+      unsigned_max = unquote(unsigned_max)
+
+      quote do
+        case unquote(value) do
+          u when is_integer(u) and u >= 0 and u <= unquote(unsigned_max) ->
+            <<u::unquote(size)-little>>
+
+          nil ->
+            <<0::unquote(size)>>
+
+          term ->
+            raise ArgumentError, "invalid UInt#{unquote(size)}: #{inspect(term)}"
+        end
+      end
+    end
+
+    defp encoder_expr(unquote(int), value) do
+      size = unquote(size)
+      signed_min = unquote(signed_min)
+      signed_max = unquote(signed_max)
+
+      quote do
+        case unquote(value) do
+          i when is_integer(i) and i >= unquote(signed_min) and i <= unquote(signed_max) ->
+            <<i::unquote(size)-little-signed>>
+
+          nil ->
+            <<0::unquote(size)>>
+
+          term ->
+            raise ArgumentError, "invalid Int#{unquote(size)}: #{inspect(term)}"
+        end
+      end
+    end
+  end
+
+  for size <- [32, 64] do
+    type = :"f#{size}"
+
+    defp encoder_expr(unquote(type), value) do
+      size = unquote(size)
+
+      quote do
+        case unquote(value) do
+          f when is_number(f) -> <<f::unquote(size)-little-signed-float>>
+          nil -> <<0::unquote(size)>>
+        end
+      end
+    end
+  end
+
+  defp encoder_expr({:fixed_string, size} = type, value) do
+    quote do
+      case unquote(value) do
+        string when is_binary(string) and byte_size(string) == unquote(size) ->
+          string
+
+        string when is_binary(string) and byte_size(string) < unquote(size) ->
+          to_pad = unquote(size) - byte_size(string)
+          [string | <<0::size(to_pad * 8)>>]
+
+        nil ->
+          <<0::size(unquote(size) * 8)>>
+
+        term ->
+          Ch.RowBinary.encode(unquote(Macro.escape(type)), term)
+      end
+    end
+  end
+
+  defp encoder_expr({:array, :u8}, value) do
+    quote do
+      Ch.RowBinary.encode_u8_array(unquote(value))
+    end
+  end
+
+  defp encoder_expr({:nullable, type}, value) do
+    encoded_value = Macro.unique_var(:encoded_value, __MODULE__)
+    present_value = Macro.unique_var(:present_value, __MODULE__)
+    expr = encoder_expr(type, present_value)
+
+    quote do
+      case unquote(value) do
+        nil ->
+          1
+
+        unquote(present_value) ->
+          case unquote(expr) do
+            unquote(encoded_value)
+            when is_list(unquote(encoded_value)) or is_binary(unquote(encoded_value)) ->
+              [0 | unquote(encoded_value)]
+
+            unquote(encoded_value) ->
+              [0, unquote(encoded_value)]
+          end
+      end
+    end
+  end
+
+  defp encoder_expr(:datetime, value) do
+    epoch = @epoch_gregorian_seconds
+
+    quote do
+      case unquote(value) do
+        %NaiveDateTime{} = datetime ->
+          {seconds, _micros} = NaiveDateTime.to_gregorian_seconds(datetime)
+          <<seconds - unquote(epoch)::32-little>>
+
+        %DateTime{} = datetime ->
+          <<DateTime.to_unix(datetime, :second)::32-little>>
+
+        nil ->
+          <<0::32>>
+      end
+    end
+  end
+
+  defp encoder_expr({:datetime64, time_unit}, value) do
+    epoch = @epoch_gregorian_seconds
+
+    quote do
+      case unquote(value) do
+        %NaiveDateTime{} = datetime ->
+          {seconds, micros} = NaiveDateTime.to_gregorian_seconds(datetime)
+
+          <<(seconds - unquote(epoch)) * unquote(time_unit) +
+              div(micros * unquote(time_unit), 1_000_000)::64-little-signed>>
+
+        %DateTime{} = datetime ->
+          <<DateTime.to_unix(datetime, unquote(time_unit))::64-little-signed>>
+
+        nil ->
+          <<0::64>>
+      end
+    end
+  end
+
+  defp encoder_expr(:date, value) do
+    epoch = @epoch_gregorian_days
+
+    quote do
+      case unquote(value) do
+        %Date{} = date -> <<Date.to_gregorian_days(date) - unquote(epoch)::16-little>>
+        nil -> <<0::16>>
+      end
+    end
+  end
+
+  defp encoder_expr(:date32, value) do
+    epoch = @epoch_gregorian_days
+
+    quote do
+      case unquote(value) do
+        %Date{} = date -> <<Date.to_gregorian_days(date) - unquote(epoch)::32-little-signed>>
+        nil -> <<0::32>>
+      end
+    end
+  end
+
+  defp encoder_expr(:time, value) do
+    quote do
+      case unquote(value) do
+        %Time{} = time ->
+          {seconds, _micros} = Time.to_seconds_after_midnight(time)
+          <<seconds::32-little-signed>>
+
+        nil ->
+          <<0::32>>
+      end
+    end
+  end
+
+  defp encoder_expr(type, value) do
+    quote do
+      Ch.RowBinary.encode(unquote(Macro.escape(type)), unquote(value))
+    end
+  end
+
+  @doc """
   Encodes a single row to [RowBinary](https://clickhouse.com/docs/en/interfaces/formats/RowBinary) as iodata.
 
   Examples:
@@ -76,6 +521,18 @@ defmodule Ch.RowBinary do
   end
 
   defp _encode_rows([], [], rows, types), do: _encode_rows(rows, types)
+
+  @doc false
+  def encode_varint(i) when is_integer(i) and i < 128, do: i
+  def encode_varint(i) when is_integer(i), do: encode_varint_cont(i)
+
+  @doc false
+  def encode_u8_array([_ | _] = bytes) do
+    [encode_varint(length(bytes)) | bytes]
+  end
+
+  def encode_u8_array([]), do: 0
+  def encode_u8_array(nil), do: 0
 
   @doc false
   def encoding_types([type | types]) do
@@ -180,8 +637,7 @@ defmodule Ch.RowBinary do
   @doc false
   def encode(type, value)
 
-  def encode(:varint, i) when is_integer(i) and i < 128, do: i
-  def encode(:varint, i) when is_integer(i), do: encode_varint_cont(i)
+  def encode(:varint, i), do: encode_varint(i)
 
   def encode(:string, str) do
     case str do

--- a/pages/query.md
+++ b/pages/query.md
@@ -110,6 +110,23 @@ Ch.query!(pool, [
 ])
 ```
 
+For hot insert paths, define the schema once and generate a row or insert-body
+encoder:
+
+```elixir
+defmodule EventInsert do
+  require Ch.RowBinary
+
+  Ch.RowBinary.define_encoder(
+    schema: [id: "UInt8", name: "String"],
+    name: :encode_insert,
+    table: "events"
+  )
+end
+
+Ch.query!(pool, EventInsert.encode_insert([%{id: 1, name: "one"}]))
+```
+
 ## Compressed Inserts
 
 ClickHouse accepts compressed request bodies when the `content-encoding` header is set. Compress the entire SQL plus data body:

--- a/test/ch/row_binary_test.exs
+++ b/test/ch/row_binary_test.exs
@@ -4,6 +4,49 @@ defmodule Ch.RowBinaryTest do
   import Ch.RowBinary
   import Bitwise
 
+  defmodule AtomKeyEncoder do
+    require Ch.RowBinary
+
+    Ch.RowBinary.define_encoder(
+      schema: [
+        id: "UInt64",
+        text: "String",
+        ok: "Bool",
+        bytes: "Array(UInt8)",
+        created_at: "DateTime"
+      ],
+      name: :encode
+    )
+  end
+
+  defmodule EventRow do
+    defstruct [:id, :text, :ok, :bytes, :created_at]
+  end
+
+  defmodule StringKeyEncoder do
+    require Ch.RowBinary
+
+    Ch.RowBinary.define_encoder(
+      schema: %{
+        "bytes" => "Array(UInt8)",
+        "id" => "UInt64",
+        "text" => "String"
+      },
+      name: :encode_many,
+      rows: true
+    )
+  end
+
+  defmodule InsertEncoder do
+    require Ch.RowBinary
+
+    Ch.RowBinary.define_encoder(
+      schema: [id: "UInt64", text: "String"],
+      name: :insert,
+      table: "events"
+    )
+  end
+
   test "encode -> decode" do
     spec = [
       {:string, ""},
@@ -232,6 +275,60 @@ defmodule Ch.RowBinaryTest do
       assert_raise ArgumentError, ~s[no matching type found for encoding "x" as Variant], fn ->
         encode({:variant, [:u8]}, "x")
       end
+    end
+  end
+
+  describe "define_encoder/1" do
+    test "defines a single row encoder for atom-keyed maps and structs" do
+      row = %EventRow{
+        id: 42,
+        text: "hello",
+        ok: true,
+        bytes: [1, 2, 3],
+        created_at: ~N[2026-01-01 12:00:00]
+      }
+
+      types = ["UInt64", "String", "Bool", "Array(UInt8)", "DateTime"]
+
+      assert IO.iodata_to_binary(AtomKeyEncoder.encode(row)) ==
+               IO.iodata_to_binary(
+                 encode_row(
+                   [row.id, row.text, row.ok, row.bytes, row.created_at],
+                   types
+                 )
+               )
+    end
+
+    test "defines a many row encoder for string-keyed maps" do
+      rows = [
+        %{"bytes" => [1, 2, 3], "id" => 1, "text" => "one"},
+        %{"bytes" => [], "id" => 2, "text" => "two"}
+      ]
+
+      generic_rows =
+        Enum.map(rows, fn row ->
+          [row["bytes"], row["id"], row["text"]]
+        end)
+
+      types = ["Array(UInt8)", "UInt64", "String"]
+
+      assert IO.iodata_to_binary(StringKeyEncoder.encode_many(rows)) ==
+               IO.iodata_to_binary(encode_rows(generic_rows, types))
+    end
+
+    test "defines a many row insert body with precomputed RowBinaryWithNamesAndTypes header" do
+      rows = [
+        %{id: 1, text: "one"},
+        %{id: 2, text: "two"}
+      ]
+
+      expected = [
+        "INSERT INTO events FORMAT RowBinaryWithNamesAndTypes\n",
+        encode_names_and_types(["id", "text"], ["UInt64", "String"]),
+        encode_rows([[1, "one"], [2, "two"]], ["UInt64", "String"])
+      ]
+
+      assert IO.iodata_to_binary(InsertEncoder.insert(rows)) == IO.iodata_to_binary(expected)
     end
   end
 


### PR DESCRIPTION
## Summary

Adds `Ch.RowBinary.define_encoder/1` for compile-time RowBinary encoders from a non-Ecto schema shape such as `schema: [id: "UInt64", text: "String"]` or `schema: %{"id" => "UInt64"}`.

The generated encoder can:

- encode one atom-keyed or string-keyed row map/struct
- encode many rows with `rows: true`
- encode a full `INSERT INTO ... FORMAT RowBinaryWithNamesAndTypes` body when `table:` is provided, with the names/types prefix precomputed

The first specialization covers common hot insert paths and falls back to `Ch.RowBinary.encode/2` for less common types.

## Benchmark

Updated `bench/encode.exs` to compare current list/map paths against the generated encoder. Local Apple M2 result for 1,000,000 rows:

```text
Predefined atom map encoder stream of 100k row chunks: 2.22 ips / 450.21 ms
Predefined atom map encoder: 1.96 ips / 509.09 ms
Predefined full insert body: 1.92 ips / 521.85 ms
RowBinary row lists: 1.00 ips / 1004.43 ms
RowBinary atom maps via fields: 0.81 ips / 1229.04 ms
```

## Follow-up Issues

- #371 Optimize RowBinary DateTime encoding in generated encoders
- #372 Explore column reordering and fixed-width packing for generated RowBinary inserts
- #373 Specialize more generated RowBinary encoder type paths

## Validation

- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix format`
- `git diff --check`
- `mix run bench/encode.exs`
- custom `mix run -e` smoke check comparing generated encoder bytes against `encode_row/2`, `encode_rows/2`, and `encode_names_and_types/2`

`mix test test/ch/row_binary_test.exs` could not run in this workspace because the Docker daemon/OrbStack socket is unavailable, so ClickHouse from `compose.yml` could not be started.
